### PR TITLE
[Threading] Reduce dispatcher allocations

### DIFF
--- a/sources/core/Xenko.Core/Threading/ConcurrentFixedPool.cs
+++ b/sources/core/Xenko.Core/Threading/ConcurrentFixedPool.cs
@@ -34,7 +34,7 @@ namespace Xenko.Core.Threading
                 Items = new T[size],
                 Mask = size - 1,
             };
-            Push(new T());
+            TryPush(new T());
         }
 
         public T Pop()
@@ -52,12 +52,12 @@ namespace Xenko.Core.Threading
             // The entire logic works on the guarantee that there is
             // always at least one item within the collection.
             if (iterator <= 0)
-                Push(new T());
+                TryPush(new T());
 
             return item;
         }
 
-        public void Push(T item)
+        public bool TryPush(T item)
         {
             var localHead = head;
             int iterator;
@@ -67,7 +67,7 @@ namespace Xenko.Core.Threading
             {
                 iterator = Volatile.Read(ref localHead.Iterator);
                 if (iterator >= localHead.Items.Length)
-                    return;
+                    return false;
                 if (Interlocked.CompareExchange(ref localHead.Iterator, iterator + 1, iterator) == iterator)
                     break;
                 spin.SpinOnce();
@@ -78,6 +78,7 @@ namespace Xenko.Core.Threading
             {
                 spin.SpinOnce();
             }
+            return true;
         }
     }
 }

--- a/sources/core/Xenko.Core/Threading/ConcurrentFixedPool.cs
+++ b/sources/core/Xenko.Core/Threading/ConcurrentFixedPool.cs
@@ -65,7 +65,7 @@ namespace Xenko.Core.Threading
             var spin = new SpinWait();
             do
             {
-                iterator = Volatile.Read(ref localHead.Iterator);
+                iterator = localHead.Iterator;
                 if (iterator >= localHead.Items.Length)
                     return false;
                 if (Interlocked.CompareExchange(ref localHead.Iterator, iterator + 1, iterator) == iterator)

--- a/sources/core/Xenko.Core/Threading/ConcurrentFixedPool.cs
+++ b/sources/core/Xenko.Core/Threading/ConcurrentFixedPool.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Xenko contributors (https://xenko.com)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Threading;
+
+namespace Xenko.Core.Threading
+{
+    /// <summary>
+    /// A stack of fixed size, that size must be a power of two,
+    /// always contains at least one item.
+    /// Fastest collection type under heavy concurrency.
+    /// </summary>
+    public class ConcurrentFixedPool<T> where T : class, new()
+    {
+        private class Segment
+        {
+            public T[] Items;
+            public int Mask;
+            public int Iterator;
+        }
+
+        private readonly Segment head;
+
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="size"/> must be a power of two</exception>
+        public ConcurrentFixedPool(int size)
+        {
+            // Size must be a power of two for modulo and overflow of read/write indices to behave correctly
+            if (size <= 0 || ((size & (size - 1)) != 0))
+                throw new ArgumentOutOfRangeException(nameof(size), "Must be power of two");
+
+            head = new Segment
+            {
+                Items = new T[size],
+                Mask = size - 1,
+            };
+            Push(new T());
+        }
+
+        public T Pop()
+        {
+            var spin = new SpinWait();
+            var localHead = head;
+            var iterator = Interlocked.Decrement(ref localHead.Iterator);
+
+            var index = iterator & localHead.Mask;
+
+            T item;
+            while ((item = Interlocked.Exchange(ref localHead.Items[index], null)) == null)
+                spin.SpinOnce();
+            
+            // The entire logic works on the guarantee that there is
+            // always at least one item within the collection.
+            if (iterator <= 0)
+                Push(new T());
+
+            return item;
+        }
+
+        public void Push(T item)
+        {
+            var localHead = head;
+            int iterator;
+
+            var spin = new SpinWait();
+            do
+            {
+                iterator = Volatile.Read(ref localHead.Iterator);
+                if (iterator >= localHead.Items.Length)
+                    return;
+                if (Interlocked.CompareExchange(ref localHead.Iterator, iterator + 1, iterator) == iterator)
+                    break;
+                spin.SpinOnce();
+            } while (true);
+
+            var index = iterator & localHead.Mask;
+            while (Interlocked.CompareExchange(ref localHead.Items[index], item, null) != null)
+            {
+                spin.SpinOnce();
+            }
+        }
+    }
+}

--- a/sources/core/Xenko.Core/Threading/Dispatcher.cs
+++ b/sources/core/Xenko.Core/Threading/Dispatcher.cs
@@ -554,7 +554,7 @@ namespace Xenko.Core.Threading
 
         private class BatchState : ThreadPool.IConcurrentJob
         {
-            private static readonly ConcurrentFixedPool<BatchState> pool = new ConcurrentFixedPool<BatchState>(64);
+            private static readonly ConcurrentFixedPool<BatchState> pool = new ConcurrentFixedPool<BatchState>(64, () => new BatchState());
             
             public readonly ManualResetEventSlim Finished = new ManualResetEventSlim(false);
             
@@ -615,7 +615,7 @@ namespace Xenko.Core.Threading
 
         private class CachedDelegateCapture<TConst, TParam> : ICachedDelegateCapture<TParam>
         {
-            private static readonly ConcurrentFixedPool<CachedDelegateCapture<TConst, TParam>> pool = new ConcurrentFixedPool<CachedDelegateCapture<TConst, TParam>>(8);
+            private static readonly ConcurrentFixedPool<CachedDelegateCapture<TConst, TParam>> pool = new ConcurrentFixedPool<CachedDelegateCapture<TConst, TParam>>(8, () => new CachedDelegateCapture<TConst, TParam>());
             private ActionRef<TConst, TParam> action;
             private TConst constant;
 

--- a/sources/core/Xenko.Core/Threading/Dispatcher.cs
+++ b/sources/core/Xenko.Core/Threading/Dispatcher.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Xenko contributors (https://xenko.com) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Xenko.Core.Annotations;
 using Xenko.Core.Collections;
@@ -17,442 +19,404 @@ namespace Xenko.Core.Threading
 #else
         public static int MaxDegreeOfParallelism = Environment.ProcessorCount;
 #endif
-
-        public delegate void ValueAction<T>(ref T obj);
-
-        public static void For(int fromInclusive, int toExclusive, [Pooled] Action<int> action)
-        {
-            using (Profile(action))
-            {
-                if (fromInclusive > toExclusive)
-                {
-                    var temp = fromInclusive;
-                    fromInclusive = toExclusive + 1;
-                    toExclusive = temp + 1;
-                }
-
-                var count = toExclusive - fromInclusive;
-                if (count == 0)
-                    return;
-
-                if (MaxDegreeOfParallelism <= 1 || count == 1)
-                {
-                    ExecuteBatch(fromInclusive, toExclusive, action);
-                }
-                else
-                {
-                    var state = BatchState.Acquire();
-                    state.StartInclusive = fromInclusive;
-
-                    try
-                    {
-                        var batchCount = Math.Min(MaxDegreeOfParallelism, count);
-                        var batchSize = (count + (batchCount - 1)) / batchCount;
-
-                        // Kick off a worker, then perform work synchronously
-                        state.AddReference();
-                        Fork(toExclusive, batchSize, MaxDegreeOfParallelism, action, state);
-
-                        // Wait for all workers to finish
-                        if (state.ActiveWorkerCount != 0)
-                            state.Finished.WaitOne();
-                    }
-                    finally
-                    {
-                        state.Release();
-                    }
-                }
-            }
-        }
-
-        public static void For<TLocal>(int fromInclusive, int toExclusive, [Pooled] Func<TLocal> initializeLocal, [Pooled] Action<int, TLocal> action, [Pooled] Action<TLocal> finalizeLocal = null)
-        {
-            using (Profile(action))
-            {
-                if (fromInclusive > toExclusive)
-                {
-                    var temp = fromInclusive;
-                    fromInclusive = toExclusive + 1;
-                    toExclusive = temp + 1;
-                }
-
-                var count = toExclusive - fromInclusive;
-                if (count == 0)
-                    return;
-
-                if (MaxDegreeOfParallelism <= 1 || count == 1)
-                {
-                    ExecuteBatch(fromInclusive, toExclusive, initializeLocal, action, finalizeLocal);
-                }
-                else
-                {
-                    var state = BatchState.Acquire();
-                    state.StartInclusive = fromInclusive;
-
-                    try
-                    {
-                        var batchCount = Math.Min(MaxDegreeOfParallelism, count);
-                        var batchSize = (count + (batchCount - 1)) / batchCount;
-
-                        // Kick off a worker, then perform work synchronously
-                        state.AddReference();
-                        Fork(toExclusive, batchSize, MaxDegreeOfParallelism, initializeLocal, action, finalizeLocal, state);
-
-                        // Wait for all workers to finish
-                        if (state.ActiveWorkerCount != 0)
-                            state.Finished.WaitOne();
-                    }
-                    finally
-                    {
-                        state.Release();
-                    }
-                }
-            }
-        }
+        public delegate TLocal InitializeLocal<TParam, TLocal>(ref TParam param);
+        public delegate void ProcessItem<TParam, TItem>(ref TParam param, TItem item);
+        public delegate void ProcessItem<TParam, TItem, TLocal>(ref TParam param, TItem item, TLocal local);
+        public delegate void ProcessKeyValue<TParam, TItem>(ref TParam param, ref TItem item);
+        public delegate void ProcessKeyValue<TParam, TItem, TLocal>(ref TParam param, ref TItem item, TLocal local);
+        public delegate void ActionRef<TParam>(ref TParam param);
+        delegate void ActionRef<TParam, TLocal>(ref TParam param, ref TLocal local);
         
-        public static void ForEach<TItem, TLocal>([NotNull] IReadOnlyList<TItem> collection, [Pooled] Func<TLocal> initializeLocal, [Pooled] Action<TItem, TLocal> action, [Pooled] Action<TLocal> finalizeLocal = null)
+        /// <summary>
+        /// Avoid using this version if you are capturing variables within the action,
+        /// use those which allows you to pass the parameter as an argument instead.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="toExclusive"/> is smaller than <paramref name="fromInclusive"/></exception>
+        public static void For(int fromInclusive, int toExclusive, Action<int> action)
         {
-            For(0, collection.Count, initializeLocal, (i, local) => action(collection[i], local), finalizeLocal);
-        }
-
-        public static void ForEach<T>([NotNull] IReadOnlyList<T> collection, [Pooled] Action<T> action)
-        {
-            For(0, collection.Count, i => action(collection[i]));
-        }
-
-        public static void ForEach<T>([NotNull] List<T> collection, [Pooled] Action<T> action)
-        {
-            For(0, collection.Count, i => action(collection[i]));
-        }
-
-        public static void ForEach<TKey, TValue>([NotNull] Dictionary<TKey, TValue> collection, [Pooled] Action<KeyValuePair<TKey, TValue>> action)
-        {
-            if (MaxDegreeOfParallelism <= 1 || collection.Count <= 1)
+            using (Profile(action))
             {
-                ExecuteBatch(collection, 0, collection.Count, action);
+                int count = toExclusive - fromInclusive;
+                if (count < 0)
+                    throw new ArgumentOutOfRangeException(nameof(toExclusive));
+                if (count == 0)
+                    return;
+
+                if (MaxDegreeOfParallelism <= 1 || count == 1)
+                {
+                    object param = null;
+                    ExecuteBatchInt<object, object>(fromInclusive, toExclusive, ref param, action, null, null);
+                }
+                else
+                {
+                    var context = AcquireCapture(delegate(ref Action<int> a, ref (int start, int end) r)
+                    {
+                        object param = null;
+                        ExecuteBatchInt<object, object>(r.start, r.end, ref param, a, null, null);
+                    }, action);
+                    PrepareFork(fromInclusive, toExclusive, context);
+                }
+            }
+        }
+
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="toExclusive"/> is smaller than <paramref name="fromInclusive"/></exception>
+        public static void For<TParam>(int fromInclusive, int toExclusive, TParam parameter, ProcessItem<TParam, int> action)
+        {
+            using (Profile(action))
+            {
+                int count = toExclusive - fromInclusive;
+                if (count < 0)
+                    throw new ArgumentOutOfRangeException(nameof(toExclusive));
+                if (count == 0)
+                    return;
+
+                if (MaxDegreeOfParallelism <= 1 || count == 1)
+                {
+                    ExecuteBatchInt<TParam, object>(fromInclusive, toExclusive, ref parameter, action, null, null);
+                }
+                else
+                {
+                    var context = AcquireCapture(delegate(ref (ProcessItem<TParam, int> action, TParam param) a, ref (int start, int end) r)
+                    {
+                        ExecuteBatchInt<TParam, object>(r.start, r.end, ref a.param, a.action, null, null);
+                    }, (action, parameter));
+                    PrepareFork(fromInclusive, toExclusive, context);
+                }
+            }
+        }
+
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="toExclusive"/> is smaller than <paramref name="fromInclusive"/></exception>
+        public static void For<TLocal>(int fromInclusive, int toExclusive, Action<int, TLocal> action, Func<TLocal> initializeLocal, Action<TLocal> finalizeLocal = null)
+        {
+            using (Profile(action))
+            {
+                int count = toExclusive - fromInclusive;
+                if (count < 0)
+                    throw new ArgumentOutOfRangeException(nameof(toExclusive));
+                if (count == 0)
+                    return;
+
+                if (MaxDegreeOfParallelism <= 1 || count == 1)
+                {
+                    object param = null;
+                    ExecuteBatchInt<object, TLocal>(fromInclusive, toExclusive, ref param, action, initializeLocal, finalizeLocal);
+                }
+                else
+                {
+                    var context = AcquireCapture(delegate(ref (Func<TLocal> initializeLocal, Action<int, TLocal> action, Action<TLocal> finalizeLocal) a, ref (int start, int end) r)
+                    {
+                        object param = null;
+                        ExecuteBatchInt<object, TLocal>(r.start, r.end, ref param, a.action, a.initializeLocal, a.finalizeLocal);
+                    }, (initializeLocal, action, finalizeLocal));
+                    PrepareFork(fromInclusive, toExclusive, context);
+                }
+            }
+        }
+
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="toExclusive"/> is smaller than <paramref name="fromInclusive"/></exception>
+        public static void For<TLocal, TParam>(int fromInclusive, int toExclusive, TParam param, ProcessItem<TParam, int, TLocal> action, InitializeLocal<TParam, TLocal> initializeLocal, ProcessItem<TParam, TLocal> finalizeLocal = null)
+        {
+            using (Profile(action))
+            {
+                int count = toExclusive - fromInclusive;
+                if (count < 0)
+                    throw new ArgumentOutOfRangeException(nameof(toExclusive));
+                if (count == 0)
+                    return;
+
+                if (MaxDegreeOfParallelism <= 1 || count == 1)
+                {
+                    ExecuteBatchInt<TParam, TLocal>(fromInclusive, toExclusive, ref param, action, initializeLocal, finalizeLocal);
+                }
+                else
+                {
+                    var context = AcquireCapture(delegate(ref (TParam param, InitializeLocal<TParam, TLocal> initializeLocal, ProcessItem<TParam, int, TLocal> action, ProcessItem<TParam, TLocal> finalizeLocal) a, ref (int start, int end) r)
+                    {
+                        ExecuteBatchInt<TParam, TLocal>(r.start, r.end, ref a.param, a.action, a.initializeLocal, a.finalizeLocal);
+                    }, (param, initializeLocal, action, finalizeLocal));
+                    PrepareFork(fromInclusive, toExclusive, context);
+                }
+            }
+        }
+
+        public static void ForEach<TItem>([NotNull] IReadOnlyList<TItem> enumerable, Action<TItem> action)
+        {
+            using (Profile(action))
+            {
+                LenientForEach<object, TItem, object>(enumerable, null, action, null, null);
+            }
+        }
+
+        public static void ForEach<TParam, TItem>([NotNull] IReadOnlyList<TItem> enumerable, TParam param, ProcessItem<TParam, TItem> action)
+        {
+            using (Profile(action))
+            {
+                LenientForEach<TParam, TItem, object>(enumerable, param, action, null, null);
+            }
+        }
+
+        public static void ForEach<TParam, TItem, TLocal>([NotNull] IReadOnlyList<TItem> enumerable, TParam param, ProcessItem<TParam, TItem, TLocal> action, InitializeLocal<TParam, TLocal> initializeLocal, ProcessItem<TParam, TLocal> finalizeLocal = null)
+        {
+            using (Profile(action))
+            {
+                LenientForEach<TParam, TItem, TLocal>(enumerable, param, action, initializeLocal, finalizeLocal);
+            }
+        }
+
+        public static void ForEach<TItem, TLocal>([NotNull] IReadOnlyList<TItem> enumerable, Action<TItem, TLocal> action, Func<TLocal> initializeLocal, Action<TLocal> finalizeLocal = null)
+        {
+            using (Profile(action))
+            {
+                LenientForEach<object, TItem, TLocal>(enumerable, null, action, initializeLocal, finalizeLocal);
+            }
+        }
+
+        private static void LenientForEach<TParam, TItem, TLocal>([NotNull] IReadOnlyList<TItem> list, TParam parameter, object action, object initializeLocal, object finalizeLocal)
+        {
+            int count = list.Count;
+            if (MaxDegreeOfParallelism <= 1 || count <= 1)
+            {
+                ExecuteBatch<TParam, TItem, TLocal>(0, count, list, ref parameter, action, initializeLocal, finalizeLocal);
             }
             else
             {
-                var state = BatchState.Acquire();
-
-                try
+                var context = AcquireCapture(delegate(ref (IEnumerable<TItem> enumerable, TParam parameter, object action, object initializeLocal, object finalizeLocal) a, ref (int start, int end) r)
                 {
-                    var batchCount = Math.Min(MaxDegreeOfParallelism, collection.Count);
-                    var batchSize = (collection.Count + (batchCount - 1)) / batchCount;
+                    ExecuteBatch<TParam, TItem, TLocal>(r.start, r.end, a.enumerable, ref a.parameter, a.action, a.initializeLocal, a.finalizeLocal);
+                }, (enumerable: list, parameter, action, initializeLocal, finalizeLocal));
+                PrepareFork(0, count, context);
+            }
+        }
 
-                    // Kick off a worker, then perform work synchronously
-                    state.AddReference();
-                    Fork(collection, batchSize, MaxDegreeOfParallelism, action, state);
-
-                    // Wait for all workers to finish
-                    if (state.ActiveWorkerCount != 0)
-                        state.Finished.WaitOne();
+        public static void ForEachKVP<TKey, TValue>([NotNull] Dictionary<TKey, TValue> collection, ActionRef<KeyValuePair<TKey, TValue>> action)
+        {
+            using (Profile(action))
+            {
+                if (MaxDegreeOfParallelism <= 1 || collection.Count <= 1)
+                {
+                    object param = null;
+                    ExecuteBatchKvP<object, TKey, TValue, object>(0, collection.Count, collection, ref param, action, null, null);
                 }
-                finally
+                else
                 {
-                    state.Release();
+                    var context = AcquireCapture(delegate(ref (Dictionary<TKey, TValue> collection, ActionRef<KeyValuePair<TKey, TValue>> action) a, ref (int start, int end) r)
+                    {
+                        object param = null;
+                        ExecuteBatchKvP<object, TKey, TValue, object>(r.start, r.end, a.collection, ref param, a.action, null, null);
+                    }, (collection, action));
+                    PrepareFork(0, collection.Count, context);
                 }
             }
         }
 
-        public static void ForEach<TKey, TValue, TLocal>([NotNull] Dictionary<TKey, TValue> collection, [Pooled] Func<TLocal> initializeLocal, [Pooled] Action<KeyValuePair<TKey, TValue>, TLocal> action, [Pooled] Action<TLocal> finalizeLocal = null)
+        public static void ForEachKVP<TKey, TValue, TLocal>([NotNull] Dictionary<TKey, TValue> collection, ProcessItem<KeyValuePair<TKey, TValue>, TLocal> action, Func<TLocal> initializeLocal, Action<TLocal> finalizeLocal = null)
         {
-            if (MaxDegreeOfParallelism <= 1 || collection.Count <= 1)
+            using (Profile(action))
             {
-                ExecuteBatch(collection, 0, collection.Count, initializeLocal, action, finalizeLocal);
-            }
-            else
-            {
-                var state = BatchState.Acquire();
-
-                try
+                if (MaxDegreeOfParallelism <= 1 || collection.Count <= 1)
                 {
-                    var batchCount = Math.Min(MaxDegreeOfParallelism, collection.Count);
-                    var batchSize = (collection.Count + (batchCount - 1)) / batchCount;
-
-                    // Kick off a worker, then perform work synchronously
-                    state.AddReference();
-                    Fork(collection, batchSize, MaxDegreeOfParallelism, initializeLocal, action, finalizeLocal, state);
-
-                    // Wait for all workers to finish
-                    if (state.ActiveWorkerCount != 0)
-                        state.Finished.WaitOne();
+                    object param = null;
+                    ExecuteBatchKvP<object, TKey, TValue, TLocal>(0, collection.Count, collection, ref param, action, initializeLocal, finalizeLocal);
                 }
-                finally
+                else
                 {
-                    state.Release();
+                    var context = AcquireCapture(delegate(ref (Dictionary<TKey, TValue> collection, ProcessItem<KeyValuePair<TKey, TValue>, TLocal> action, Func<TLocal> initializeLocal, Action<TLocal> finalizeLocal) a, ref (int start, int end) r)
+                    {
+                        object param = null;
+                        ExecuteBatchKvP<object, TKey, TValue, TLocal>(r.start, r.end, a.collection, ref param, a.action, a.initializeLocal, a.finalizeLocal);
+                    }, (collection, action, initializeLocal, finalizeLocal));
+                    PrepareFork(0, collection.Count, context);
                 }
             }
         }
 
-        public static void ForEach<T>([NotNull] FastCollection<T> collection, [Pooled] Action<T> action)
+        public static void ForEachKVP<TParam, TKey, TValue>([NotNull] Dictionary<TKey, TValue> collection, TParam param, ProcessKeyValue<TParam, KeyValuePair<TKey, TValue>> action)
         {
-            For(0, collection.Count, i => action(collection[i]));
-        }
-
-        public static void ForEach<T>([NotNull] FastList<T> collection, [Pooled] Action<T> action)
-        {
-            For(0, collection.Count, i => action(collection.Items[i]));
-        }
-
-        public static void ForEach<T>([NotNull] ConcurrentCollector<T> collection, [Pooled] Action<T> action)
-        {
-            For(0, collection.Count, i => action(collection.Items[i]));
-        }
-
-        public static void ForEach<T>([NotNull] FastList<T> collection, [Pooled] ValueAction<T> action)
-        {
-            For(0, collection.Count, i => action(ref collection.Items[i]));
-        }
-
-        public static void ForEach<T>([NotNull] ConcurrentCollector<T> collection, [Pooled] ValueAction<T> action)
-        {
-            For(0, collection.Count, i => action(ref collection.Items[i]));
-        }
-
-        private static void Fork<TKey, TValue>([NotNull] Dictionary<TKey, TValue> collection, int batchSize, int maxDegreeOfParallelism, [Pooled] Action<KeyValuePair<TKey, TValue>> action, [NotNull] BatchState state)
-        {
-            // Other threads already processed all work before this one started. ActiveWorkerCount is already 0
-            if (state.StartInclusive >= collection.Count)
+            using (Profile(action))
             {
-                state.Release();
+                if (MaxDegreeOfParallelism <= 1 || collection.Count <= 1)
+                {
+                    ExecuteBatchKvP<TParam, TKey, TValue, object>(0, collection.Count, collection, ref param, action, null, null);
+                }
+                else
+                {
+                    var context = AcquireCapture(delegate(ref (Dictionary<TKey, TValue> collection, TParam param, ProcessKeyValue<TParam, KeyValuePair<TKey, TValue>> action) a, ref (int start, int end) r)
+                    {
+                        ExecuteBatchKvP<TParam, TKey, TValue, object>(r.start, r.end, a.collection, ref a.param, a.action, null, null);
+                    }, (collection, param, action));
+                    PrepareFork(0, collection.Count, context);
+                }
+            }
+        }
+
+        public static void ForEachKVP<TParam, TKey, TValue, TLocal>([NotNull] Dictionary<TKey, TValue> collection, TParam param, ProcessKeyValue<TParam, KeyValuePair<TKey, TValue>, TLocal> action, InitializeLocal<TParam, TLocal> initializeLocal, ProcessItem<TParam, TLocal> finalizeLocal = null)
+        {
+            using (Profile(action))
+            {
+                if (MaxDegreeOfParallelism <= 1 || collection.Count <= 1)
+                {
+                    ExecuteBatchKvP<TParam, TKey, TValue, TLocal>(0, collection.Count, collection, ref param, action, initializeLocal, finalizeLocal);
+                }
+                else
+                {
+                    var context = AcquireCapture(delegate(ref (Dictionary<TKey, TValue> collection, TParam param, ProcessKeyValue<TParam, KeyValuePair<TKey, TValue>, TLocal> action, InitializeLocal<TParam, TLocal> initializeLocal, ProcessItem<TParam, TLocal> finalizeLocal) a, ref (int start, int end) r)
+                    {
+                        ExecuteBatchKvP<TParam, TKey, TValue, TLocal>(r.start, r.end, a.collection, ref a.param, a.action, a.initializeLocal, a.finalizeLocal);
+                    }, (collection, param, action, initializeLocal, finalizeLocal));
+                    PrepareFork(0, collection.Count, context);
+                }
+            }
+        }
+
+        private static void PrepareFork(int fromInclusive, int toExclusive, ICachedDelegateCapture<(int, int)> executeBatch)
+        {
+            int count = toExclusive - fromInclusive;
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(toExclusive));
+            if (count == 0)
                 return;
-            }
 
-            // This thread is now actively processing work items, meaning there might be work in progress
-            Interlocked.Increment(ref state.ActiveWorkerCount);
-
-            // Kick off another worker if there's any work left
-            if (maxDegreeOfParallelism > 1 && state.StartInclusive + batchSize < collection.Count)
+            var tCount = Math.Min(MaxDegreeOfParallelism, count);
+            var batchSize = count / tCount;
+            batchSize = batchSize > 1 ? batchSize / 2 : batchSize;
+            var state = BatchState.Acquire(tCount, fromInclusive, toExclusive, batchSize, executeBatch);
+            for (int i = 0; i < tCount - 1; i++)
             {
-                state.AddReference();
-                ThreadPool.Instance.QueueWorkItem(() => Fork(collection, batchSize, maxDegreeOfParallelism - 1, action, state));
+                ThreadPool.Instance.DispatchJob(state);
             }
 
-            try
-            {
-                // Process batches synchronously as long as there are any
-                int newStart;
-                while ((newStart = Interlocked.Add(ref state.StartInclusive, batchSize)) - batchSize < collection.Count)
-                {
-                    // TODO: Reuse enumerator when processing multiple batches synchronously
-                    var start = newStart - batchSize;
-                    ExecuteBatch(collection, newStart - batchSize, Math.Min(collection.Count, newStart) - start, action);
-                }
-            }
-            finally
-            {
-                state.Release();
+            state.Work();
 
-                // If this was the last batch, signal
-                if (Interlocked.Decrement(ref state.ActiveWorkerCount) == 0)
-                {
-                    state.Finished.Set();
-                }
-            }
+            // Wait for job to finish
+            state.Finished.Wait();
         }
 
-        private static void Fork<TKey, TValue, TLocal>([NotNull] Dictionary<TKey, TValue> collection, int batchSize, int maxDegreeOfParallelism, [Pooled] Func<TLocal> initializeLocal, [Pooled] Action<KeyValuePair<TKey, TValue>, TLocal> action, [Pooled] Action<TLocal> finalizeLocal, [NotNull] BatchState state)
-        {
-            // Other threads already processed all work before this one started. ActiveWorkerCount is already 0
-            if (state.StartInclusive >= collection.Count)
-            {
-                state.Release();
-                return;
-            }
-
-            // This thread is now actively processing work items, meaning there might be work in progress
-            Interlocked.Increment(ref state.ActiveWorkerCount);
-
-            // Kick off another worker if there's any work left
-            if (maxDegreeOfParallelism > 1 && state.StartInclusive + batchSize < collection.Count)
-            {
-                state.AddReference();
-                ThreadPool.Instance.QueueWorkItem(() => Fork(collection, batchSize, maxDegreeOfParallelism - 1, initializeLocal, action, finalizeLocal, state));
-            }
-
-            try
-            {
-                // Process batches synchronously as long as there are any
-                int newStart;
-                while ((newStart = Interlocked.Add(ref state.StartInclusive, batchSize)) - batchSize < collection.Count)
-                {
-                    // TODO: Reuse enumerator when processing multiple batches synchronously
-                    var start = newStart - batchSize;
-                    ExecuteBatch(collection, newStart - batchSize, Math.Min(collection.Count, newStart) - start, initializeLocal, action, finalizeLocal);
-                }
-            }
-            finally
-            {
-                state.Release();
-
-                // If this was the last batch, signal
-                if (Interlocked.Decrement(ref state.ActiveWorkerCount) == 0)
-                {
-                    state.Finished.Set();
-                }
-            }
-        }
-
-        private static void ExecuteBatch(int fromInclusive, int toExclusive, [Pooled] Action<int> action)
-        {
-            for (var i = fromInclusive; i < toExclusive; i++)
-            {
-                action(i);
-            }
-        }
-
-        private static void ExecuteBatch<TLocal>(int fromInclusive, int toExclusive, [Pooled] Func<TLocal> initializeLocal, [Pooled] Action<int, TLocal> action, [Pooled] Action<TLocal> finalizeLocal)
+        private static void ExecuteBatchInt<TParam, TLocal>(int fromInclusive, int toExclusive, ref TParam parameter, object action, object initializeLocal, object finalizeLocal)
         {
             var local = default(TLocal);
             try
             {
-                if (initializeLocal != null)
+                switch (initializeLocal)
                 {
-                    local = initializeLocal();
+                    case InitializeLocal<TParam, TLocal> fpl: local = fpl(ref parameter); break;
+                    case Func<TLocal> fl: local = fl(); break;
+                    case object o: throw new ArgumentException(initializeLocal.GetType().ToString());
                 }
 
+                var proxy = new ActionProxy<TParam, int, TLocal>(action);
                 for (var i = fromInclusive; i < toExclusive; i++)
                 {
-                    action(i, local);
+                    proxy.Invoke(ref parameter, ref i, local);
                 }
             }
             finally
             {
-                finalizeLocal?.Invoke(local);
-            }
-        }
-
-        private static void Fork(int endExclusive, int batchSize, int maxDegreeOfParallelism, [Pooled] Action<int> action, [NotNull] BatchState state)
-        {
-            // Other threads already processed all work before this one started. ActiveWorkerCount is already 0
-            if (state.StartInclusive >= endExclusive)
-            {
-                state.Release();
-                return;
-            }
-
-            // This thread is now actively processing work items, meaning there might be work in progress
-            Interlocked.Increment(ref state.ActiveWorkerCount);
-
-            // Kick off another worker if there's any work left
-            if (maxDegreeOfParallelism > 1 && state.StartInclusive + batchSize < endExclusive)
-            {
-                state.AddReference();
-                ThreadPool.Instance.QueueWorkItem(() => Fork(endExclusive, batchSize, maxDegreeOfParallelism - 1, action, state));
-            }
-
-            try
-            {
-                // Process batches synchronously as long as there are any
-                int newStart;
-                while ((newStart = Interlocked.Add(ref state.StartInclusive, batchSize)) - batchSize < endExclusive)
+                switch (finalizeLocal)
                 {
-                    ExecuteBatch(newStart - batchSize, Math.Min(endExclusive, newStart), action);
-                }
-            }
-            finally
-            {
-                state.Release();
-
-                // If this was the last batch, signal
-                if (Interlocked.Decrement(ref state.ActiveWorkerCount) == 0)
-                {
-                    state.Finished.Set();
+                    case ProcessItem<TParam, TLocal> apl: apl(ref parameter, local); break;
+                    case Action<TLocal> al: al(local); break;
+                    case object o: throw new ArgumentException(finalizeLocal.GetType().ToString());
                 }
             }
         }
 
-        private static void Fork<TLocal>(int endExclusive, int batchSize, int maxDegreeOfParallelism, [Pooled] Func<TLocal> initializeLocal, [Pooled] Action<int, TLocal> action, [Pooled] Action<TLocal> finalizeLocal, [NotNull] BatchState state)
-        {
-            // Other threads already processed all work before this one started. ActiveWorkerCount is already 0
-            if (state.StartInclusive >= endExclusive)
-            {
-                state.Release();
-                return;
-            }
-
-            // This thread is now actively processing work items, meaning there might be work in progress
-            Interlocked.Increment(ref state.ActiveWorkerCount);
-
-            // Kick off another worker if there's any work left
-            if (maxDegreeOfParallelism > 1 && state.StartInclusive + batchSize < endExclusive)
-            {
-                state.AddReference();
-                ThreadPool.Instance.QueueWorkItem(() => Fork(endExclusive, batchSize, maxDegreeOfParallelism - 1, initializeLocal, action, finalizeLocal, state));
-            }
-
-            try
-            {
-                // Process batches synchronously as long as there are any
-                int newStart;
-                while ((newStart = Interlocked.Add(ref state.StartInclusive, batchSize)) - batchSize < endExclusive)
-                {
-                    ExecuteBatch(newStart - batchSize, Math.Min(endExclusive, newStart), initializeLocal, action, finalizeLocal);
-                }
-            }
-            finally
-            {
-                state.Release();
-
-                // If this was the last batch, signal
-                if (Interlocked.Decrement(ref state.ActiveWorkerCount) == 0)
-                {
-                    state.Finished.Set();
-                }
-            }
-        }
-
-        private static void ExecuteBatch<TKey, TValue>([NotNull] Dictionary<TKey, TValue> dictionary, int offset, int count, [Pooled] Action<KeyValuePair<TKey, TValue>> action)
-        {
-            var enumerator = dictionary.GetEnumerator();
-            var index = 0;
-
-            // Skip to offset
-            while (index < offset && enumerator.MoveNext())
-            {
-                index++;
-            }
-
-            // Process batch
-            while (index < offset + count && enumerator.MoveNext())
-            {
-                action(enumerator.Current);
-                index++;
-            }
-        }
-
-        private static void ExecuteBatch<TKey, TValue, TLocal>([NotNull] Dictionary<TKey, TValue> dictionary, int offset, int count, [Pooled] Func<TLocal> initializeLocal, [Pooled] Action<KeyValuePair<TKey, TValue>, TLocal> action, [Pooled] Action<TLocal> finalizeLocal)
+        private static void ExecuteBatch<TParam, TItem, TLocal>(int fromInclusive, int toExclusive, IEnumerable<TItem> enumerable, ref TParam parameter, object action, object initializeLocal, object finalizeLocal)
         {
             var local = default(TLocal);
             try
             {
-                if (initializeLocal != null)
+                switch (initializeLocal)
                 {
-                    local = initializeLocal();
+                    case InitializeLocal<TParam, TLocal> fpl: local = fpl(ref parameter); break;
+                    case Func<TLocal> fl: local = fl(); break;
+                    case object o: throw new ArgumentException(initializeLocal.GetType().ToString());
+                }
+
+                if (enumerable is FastList<TItem> fastList)
+                    enumerable = fastList.Items;
+                else if (enumerable is ConcurrentCollector<TItem> collector)
+                    enumerable = collector.Items;
+
+                var proxy = new ActionProxy<TParam, TItem, TLocal>(action);
+                switch (enumerable)
+                {
+                    case TItem[] array:
+                    {
+                        for (var i = fromInclusive; i < toExclusive; i++)
+                        {
+                            proxy.Invoke(ref parameter, ref array[i], local);
+                        }
+
+                        break;
+                    }
+                    case IReadOnlyList<TItem> iList:
+                    {
+                        for (var i = fromInclusive; i < toExclusive; i++)
+                        {
+                            var item = iList[i];
+                            proxy.Invoke(ref parameter, ref item, local);
+                        }
+
+                        break;
+                    }
+                    default: throw new ArgumentException(enumerable.GetType().ToString());
+                }
+            }
+            finally
+            {
+                switch (finalizeLocal)
+                {
+                    case ProcessItem<TParam, TLocal> apl: apl(ref parameter, local); break;
+                    case Action<TLocal> al: al(local); break;
+                    case object o: throw new ArgumentException(finalizeLocal.GetType().ToString());
+                }
+            }
+        }
+
+        private static void ExecuteBatchKvP<TParam, TKey, TValue, TLocal>(int fromInclusive, int toExclusive, [NotNull] Dictionary<TKey, TValue> dictionary, ref TParam parameter, object action, object initializeLocal, object finalizeLocal)
+        {
+            var local = default(TLocal);
+            try
+            {
+                switch (initializeLocal)
+                {
+                    case InitializeLocal<TParam, TLocal> fpl: local = fpl(ref parameter); break;
+                    case Func<TLocal> fl: local = fl(); break;
+                    case object o: throw new ArgumentException(initializeLocal.GetType().ToString());
                 }
 
                 var enumerator = dictionary.GetEnumerator();
                 var index = 0;
+                enumerator.MoveNext();
 
                 // Skip to offset
-                while (index < offset && enumerator.MoveNext())
+                while (index < fromInclusive)
                 {
                     index++;
+                    enumerator.MoveNext();
                 }
 
+                var proxy = new ActionProxy<TParam, KeyValuePair<TKey, TValue>, TLocal>(action);
                 // Process batch
-                while (index < offset + count && enumerator.MoveNext())
+                while (index < toExclusive)
                 {
-                    action(enumerator.Current, local);
+                    var c = enumerator.Current;
+                    proxy.Invoke(ref parameter, ref c, local);
                     index++;
+                    enumerator.MoveNext();
                 }
             }
             finally
             {
-                finalizeLocal?.Invoke(local);
+                switch (finalizeLocal)
+                {
+                    case ProcessItem<TParam, TLocal> apl: apl(ref parameter, local); break;
+                    case Action<TLocal> al: al(local); break;
+                    case object o: throw new ArgumentException(finalizeLocal.GetType().ToString());
+                }
             }
         }
+
 
         public static void Sort<T>([NotNull] ConcurrentCollector<T> collection, IComparer<T> comparer)
         {
@@ -531,7 +495,7 @@ namespace Xenko.Core.Threading
                         if (maxDegreeOfParallelism > 1 && !hasChild)
                         {
                             state.AddReference();
-                            Fork(collection, maxDegreeOfParallelism, comparer, state);
+                            ThreadPool.Instance.QueueWorkItem(() => Sort(collection, maxDegreeOfParallelism - 1, comparer, state));
                             hasChild = true;
                         }
                     }
@@ -546,11 +510,6 @@ namespace Xenko.Core.Threading
                     state.Finished.Set();
                 }
             }
-        }
-
-        private static void Fork<T>(T[] collection, int maxDegreeOfParallelism, IComparer<T> comparer, SortState state)
-        {
-            ThreadPool.Instance.QueueWorkItem(() => Sort(collection, maxDegreeOfParallelism - 1, comparer, state));
         }
 
         private static int Partition<T>([NotNull] T[] collection, int left, int right, [NotNull] IComparer<T> comparer)
@@ -587,7 +546,8 @@ namespace Xenko.Core.Threading
 
             return mid;
         }
-
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void Swap<T>([NotNull] T[] collection, int i, int j)
         {
             var temp = collection[i];
@@ -595,43 +555,170 @@ namespace Xenko.Core.Threading
             collection[j] = temp;
         }
 
-        private class BatchState
+        private class BatchState : ThreadPool.IConcurrentJob
         {
-            private static readonly ConcurrentPool<BatchState> Pool = new ConcurrentPool<BatchState>(() => new BatchState());
-
+            private static readonly ConcurrentFixedPool<BatchState> pool = new ConcurrentFixedPool<BatchState>(64);
+            
+            public readonly ManualResetEventSlim Finished = new ManualResetEventSlim(false);
+            
+            private int startInclusive;
+            private int amountFinishedInclusive;
             private int referenceCount;
-
-            public readonly ManualResetEvent Finished = new ManualResetEvent(false);
-
-            public int StartInclusive;
-
-            public int ActiveWorkerCount;
+            private int toExclusive;
+            private int batchSize;
+            private ICachedDelegateCapture<(int, int)> job;
 
             [NotNull]
-            public static BatchState Acquire()
+            public static BatchState Acquire(int referenceCount, int fromInclusive, int toExclusive, int batchSize, ICachedDelegateCapture<(int, int)> job)
             {
-                var state = Pool.Acquire();
-                state.referenceCount = 1;
-                state.ActiveWorkerCount = 0;
-                state.StartInclusive = 0;
+                var state = pool.Pop();
+                Interlocked.Exchange(ref state.referenceCount, referenceCount);
+                Interlocked.Exchange(ref state.startInclusive, fromInclusive);
+                Interlocked.Exchange(ref state.amountFinishedInclusive, fromInclusive);
+                Interlocked.Exchange(ref state.toExclusive, toExclusive);
+                Interlocked.Exchange(ref state.batchSize, batchSize);
+                if (Interlocked.Exchange(ref state.job, job) != null)
+                    throw new Exception("NON-NULL JOB");
                 state.Finished.Reset();
                 return state;
             }
 
-            public void AddReference()
+            public void Work()
             {
-                Interlocked.Increment(ref referenceCount);
-            }
-
-            public void Release()
-            {
-                if (Interlocked.Decrement(ref referenceCount) == 0)
+                try
                 {
-                    Pool.Release(this);
+                    int newStart;
+                    while ((newStart = Interlocked.Add(ref startInclusive, batchSize)) - batchSize < toExclusive)
+                    {
+                        var range = (newStart - batchSize, Math.Min(toExclusive, newStart));
+                        job.Invoke(ref range);
+                        if (Interlocked.Add(ref amountFinishedInclusive, batchSize) >= toExclusive)
+                        {
+                            Finished.Set();
+                            break;
+                        }
+                    }
+                }
+                finally
+                {
+                    if (Interlocked.Decrement(ref referenceCount) == 0)
+                    {
+                        job.Recycle();
+                        Interlocked.Exchange(ref job, null);
+                        pool.Push(this);
+                    }
                 }
             }
         }
 
+        private static CachedDelegateCapture<TConst, (int, int)> AcquireCapture<TConst>(ActionRef<TConst, (int start, int end)> actionParam, TConst constantParam)
+        {
+            return CachedDelegateCapture<TConst, (int, int)>.Acquire(actionParam, ref constantParam);
+        }
+
+        private class CachedDelegateCapture<TConst, TParam> : ICachedDelegateCapture<TParam>
+        {
+            private static readonly ConcurrentFixedPool<CachedDelegateCapture<TConst, TParam>> pool = new ConcurrentFixedPool<CachedDelegateCapture<TConst, TParam>>(8);
+            private ActionRef<TConst, TParam> action;
+            private TConst constant;
+
+            public static CachedDelegateCapture<TConst, TParam> Acquire(ActionRef<TConst, TParam> actionParam, ref TConst constantParam)
+            {
+                var output = pool.Pop();
+                output.action = actionParam;
+                output.constant = constantParam;
+                return output;
+            }
+
+            public void Invoke(ref TParam param)
+            {
+                action(ref constant, ref param);
+            }
+
+            public void Recycle()
+            {
+                action = null;
+                constant = default;
+                pool.Push(this);
+            }
+        }
+
+        private interface ICachedDelegateCapture<T>
+        {
+            void Invoke(ref T param);
+            void Recycle();
+        }
+
+        private struct ActionProxy<TParam, TItem, TLocal>
+        {
+            private readonly int selectedAction;
+            private readonly Action<TItem> ai;
+            private readonly Action<TItem, TLocal> ail;
+            private readonly ProcessItem<TParam, TItem> api;
+            private readonly ProcessItem<TParam, TItem, TLocal> apil;
+            private readonly ProcessKeyValue<TParam, TItem> apkv;
+            private readonly ProcessKeyValue<TParam, TItem, TLocal> apkvl;
+            private readonly ActionRef<TItem> ari;
+            private readonly ActionRef<TItem, TLocal> aril;
+
+            public ActionProxy(object action)
+            {
+                this = default;
+                switch (action)
+                {
+                    case Action<TItem> a:
+                        ai = a;
+                        selectedAction = 1;
+                        break;
+                    case Action<TItem, TLocal> a:
+                        ail = a;
+                        selectedAction = 2;
+                        break;
+                    case ProcessItem<TParam, TItem> a:
+                        api = a;
+                        selectedAction = 3;
+                        break;
+                    case ProcessItem<TParam, TItem, TLocal> a:
+                        apil = a;
+                        selectedAction = 4;
+                        break;
+                    case ProcessKeyValue<TParam, TItem> a:
+                        apkv = a;
+                        selectedAction = 5;
+                        break;
+                    case ProcessKeyValue<TParam, TItem, TLocal> a:
+                        apkvl = a;
+                        selectedAction = 6;
+                        break;
+                    case ActionRef<TItem> a:
+                        ari = a;
+                        selectedAction = 7;
+                        break;
+                    case ActionRef<TItem, TLocal> a:
+                        aril = a;
+                        selectedAction = 8;
+                        break;
+                    default: throw new ArgumentException(action.GetType().ToString());
+                }
+            }
+
+            public void Invoke(ref TParam parameter, ref TItem item, TLocal local)
+            {
+                switch (selectedAction)
+                {
+                    case 1: ai(item); break;
+                    case 2: ail(item, local); break;
+                    case 3: api(ref parameter, item); break;
+                    case 4: apil(ref parameter, item, local); break;
+                    case 5: apkv(ref parameter, ref item); break;
+                    case 6: apkvl(ref parameter, ref item, local); break;
+                    case 7: ari(ref item); break;
+                    case 8: aril(ref item, ref local); break;
+                    default: throw new ArgumentException(selectedAction.ToString());
+                }
+            }
+        }
+        
         private struct SortRange
         {
             public readonly int Left;
@@ -690,6 +777,17 @@ namespace Xenko.Core.Threading
 
         private static ConcurrentDictionary<MethodInfo, DispatcherNode> nodes = new ConcurrentDictionary<MethodInfo, DispatcherNode>();
 
+        private static ProfilingScope Profile(Delegate action)
+        {
+            var result = new ProfilingScope();
+#if false
+            result.Action = action;
+            result.Stopwatch = new Stopwatch();
+            result.Stopwatch.Start();
+#endif
+            return result;
+        }
+
         private struct ProfilingScope : IDisposable
         {
 #if false
@@ -727,17 +825,6 @@ namespace Xenko.Core.Threading
                 }
 #endif
             }
-        }
-
-        private static ProfilingScope Profile(Delegate action)
-        {
-            var result = new ProfilingScope();
-#if false
-            result.Action = action;
-            result.Stopwatch = new Stopwatch();
-            result.Stopwatch.Start();
-#endif
-            return result;
         }
     }
 }

--- a/sources/core/Xenko.Core/Threading/Dispatcher.cs
+++ b/sources/core/Xenko.Core/Threading/Dispatcher.cs
@@ -605,7 +605,7 @@ namespace Xenko.Core.Threading
                     {
                         job.Recycle();
                         Interlocked.Exchange(ref job, null);
-                        pool.Push(this);
+                        pool.TryPush(this);
                     }
                 }
             }
@@ -639,7 +639,7 @@ namespace Xenko.Core.Threading
             {
                 action = null;
                 constant = default;
-                pool.Push(this);
+                pool.TryPush(this);
             }
         }
 

--- a/sources/core/Xenko.Core/Threading/Dispatcher.cs
+++ b/sources/core/Xenko.Core/Threading/Dispatcher.cs
@@ -280,10 +280,7 @@ namespace Xenko.Core.Threading
             var batchSize = count / tCount;
             batchSize = batchSize > 1 ? batchSize / 2 : batchSize;
             var state = BatchState.Acquire(tCount, fromInclusive, toExclusive, batchSize, executeBatch);
-            for (int i = 0; i < tCount - 1; i++)
-            {
-                ThreadPool.Instance.DispatchJob(state);
-            }
+            ThreadPool.Instance.DispatchJob(state, tCount - 1);
 
             state.Work();
 

--- a/sources/core/Xenko.Core/Threading/ThreadPool.cs
+++ b/sources/core/Xenko.Core/Threading/ThreadPool.cs
@@ -86,7 +86,7 @@ namespace Xenko.Core.Threading
             var spin = new SpinWait();
             while (spin.NextSpinWillYield == false)
             {
-                int spinRelease = Volatile.Read(ref spinToRelease);
+                int spinRelease = spinToRelease;
                 if (spinRelease > 0 && Interlocked.CompareExchange(ref spinToRelease, spinRelease - 1, spinRelease) == spinRelease)
                 {
                     Interlocked.Decrement(ref spinningCount);
@@ -127,7 +127,7 @@ namespace Xenko.Core.Threading
             int semaphoreToRelease;
             while (true)
             {
-                var sleepingSample = Volatile.Read(ref sleeping);
+                var sleepingSample = sleeping;
                 semaphoreToRelease = sleepingSample > releaseCount ? releaseCount : sleepingSample;
                 if (Interlocked.CompareExchange(ref sleeping, sleepingSample - semaphoreToRelease, sleepingSample) == sleepingSample)
                     break;

--- a/sources/core/Xenko.Core/Threading/ThreadPool.cs
+++ b/sources/core/Xenko.Core/Threading/ThreadPool.cs
@@ -133,8 +133,9 @@ namespace Xenko.Core.Threading
                     break;
                 spin.SpinOnce();
             }
-
-            semaphore.Release(semaphoreToRelease);
+            
+            if (semaphoreToRelease > 0)
+                semaphore.Release(semaphoreToRelease);
 
             leftThatCouldntBeReleased = releaseCount - semaphoreToRelease;
         }

--- a/sources/core/Xenko.Core/Threading/ThreadPool.cs
+++ b/sources/core/Xenko.Core/Threading/ThreadPool.cs
@@ -142,7 +142,8 @@ namespace Xenko.Core.Threading
 
                     Interlocked.Exchange(ref currentSignal, SIGNAL_IDLE);
                     // We're idle, push this thread onto the stack to wait for signal
-                    pool.Push(this);
+                    if (pool.TryPush(this) == false)
+                        return;
                     
                     SpinWait sw = new SpinWait();
                     do

--- a/sources/engine/Xenko.Engine/Engine/Processors/TransformProcessor.cs
+++ b/sources/engine/Xenko.Engine/Engine/Processors/TransformProcessor.cs
@@ -95,7 +95,7 @@ namespace Xenko.Engine.Processors
 
         internal void UpdateTransformations(FastCollection<TransformComponent> transformationComponents)
         {
-            Dispatcher.ForEach(transformationComponents, UpdateTransformationAndChildren);
+            Dispatcher.ForEach(transformationComponents, i => UpdateTransformationAndChildren(i));
 
             // Re-update model node links to avoid one frame delay compared reference model (ideally entity should be sorted to avoid this in future).
             if (ModelNodeLinkProcessor != null)
@@ -105,7 +105,7 @@ namespace Xenko.Engine.Processors
                 {
                     modelNodeLinkComponents.Add(modelNodeLink.Entity.Transform);
                 }
-                Dispatcher.ForEach(modelNodeLinkComponents, UpdateTransformationAndChildren);
+                Dispatcher.ForEach(modelNodeLinkComponents, i => UpdateTransformationAndChildren(i));
             }
         }
 
@@ -168,7 +168,7 @@ namespace Xenko.Engine.Processors
                 UpdateTransfromationsRecursive(childScene);
             }
         }
-        
+
         internal void NotifyChildrenCollectionChanged(TransformComponent transformComponent, bool added)
         {
             // Ignore if transform component is being moved inside the same root scene (no need to add/remove)
@@ -177,7 +177,7 @@ namespace Xenko.Engine.Processors
                 // Still need to update transformation roots
                 if (transformComponent.Parent == null)
                 {
-                    if(added)
+                    if (added)
                     {
                         TransformationRoots.Add(transformComponent);
                     }

--- a/sources/engine/Xenko.Engine/Rendering/ModelRenderProcessor.cs
+++ b/sources/engine/Xenko.Engine/Rendering/ModelRenderProcessor.cs
@@ -72,13 +72,13 @@ namespace Xenko.Rendering
             // Note: we are rebuilding RenderMeshes every frame
             // TODO: check if it wouldn't be better to add/remove directly in CheckMeshes()?
             //foreach (var entity in ComponentDatas)
-            Dispatcher.ForEach(ComponentDatas, entity =>
+            Dispatcher.ForEachKVP(ComponentDatas, this, delegate (ref ModelRenderProcessor @this, ref KeyValuePair<ModelComponent, RenderModel> entity)
             {
                 var modelComponent = entity.Key;
                 var renderModel = entity.Value;
 
-                CheckMeshes(modelComponent, renderModel);
-                UpdateRenderModel(modelComponent, renderModel);
+                @this.CheckMeshes(modelComponent, renderModel);
+                @this.UpdateRenderModel(modelComponent, renderModel);
             });
         }
 

--- a/sources/engine/Xenko.Particles/Components/ParticleSystemSimulationProcessor.cs
+++ b/sources/engine/Xenko.Particles/Components/ParticleSystemSimulationProcessor.cs
@@ -110,7 +110,7 @@ namespace Xenko.Particles.Components
                 }
             }
 
-            Dispatcher.ForEach(ParticleSystems, state => UpdateParticleSystem(state, deltaTime));
+            Dispatcher.ForEach(ParticleSystems, (@this: this, deltaTime), (ref (ParticleSystemSimulationProcessor @this, float deltaTime) p, ParticleSystemComponentState state) => p.@this.UpdateParticleSystem(state, p.deltaTime));
         }
 
         /// <inheritdoc />

--- a/sources/engine/Xenko.Physics/Shapes/HeightfieldColliderShape.cs
+++ b/sources/engine/Xenko.Physics/Shapes/HeightfieldColliderShape.cs
@@ -253,13 +253,13 @@ namespace Xenko.Physics.Shapes
 
             public void Update(CommandList commandList)
             {
-                Dispatcher.ForEach(Tiles, (tile) =>
+                Dispatcher.ForEach(Tiles, this, (ref HeightfieldDebugPrimitive @this, Tile tile) =>
                 {
                     for (int j = 0; j <= tile.Height; ++j)
                     {
                         for (int i = 0; i <= tile.Width; ++i)
                         {
-                            GetHeightStickHeightAndColor(tile.Point.X + i, tile.Point.Y + j, out var heightStickHeight, out var color);
+                            @this.GetHeightStickHeightAndColor(tile.Point.X + i, tile.Point.Y + j, out var heightStickHeight, out var color);
 
                             var index = j * (tile.Width + 1) + i;
                             tile.Vertices[index].Position.Y = heightStickHeight;

--- a/sources/engine/Xenko.Rendering/Rendering/Lights/ForwardLightingRenderFeature.cs
+++ b/sources/engine/Xenko.Rendering/Rendering/Lights/ForwardLightingRenderFeature.cs
@@ -287,7 +287,7 @@ namespace Xenko.Rendering.Lights
                 if (!renderMesh.MaterialPass.IsLightDependent)
                     return;
 
-                var staticObjectNode = renderMesh.StaticObjectNode;
+                    var staticObjectNode = renderMesh.StaticObjectNode;
 
                 for (int i = 0; i < effectSlotCount; ++i)
                 {
@@ -417,7 +417,7 @@ namespace Xenko.Rendering.Lights
                     if (drawLayout == null)
                         return;
 
-                    var drawLighting = drawLayout.GetLogicalGroup(drawLightingKey);
+                    var drawLighting = drawLayout.GetLogicalGroup(@this.drawLightingKey);
                     if (drawLighting.Hash == ObjectId.Empty)
                         return;
 
@@ -437,13 +437,13 @@ namespace Xenko.Rendering.Lights
                     Debug.Assert(drawLighting.Hash == locals.DrawLayoutHash, "PerDraw Lighting layout differs between different RenderObject in the same RenderView");
 
                     // Compute PerDraw lighting
-                    foreach (var directLightGroup in shaderPermutation.DirectLightGroups)
+                    foreach (var directLightGroup in @this.shaderPermutation.DirectLightGroups)
                     {
-                        directLightGroup.ApplyDrawParameters(context, viewIndex, locals.DrawParameters, ref renderNode.RenderObject.BoundingBox);
+                        directLightGroup.ApplyDrawParameters(pContext, pViewIndex, locals.DrawParameters, ref renderNode.RenderObject.BoundingBox);
                     }
-                    foreach (var environmentLight in shaderPermutation.EnvironmentLights)
+                    foreach (var environmentLight in @this.shaderPermutation.EnvironmentLights)
                     {
-                        environmentLight.ApplyDrawParameters(context, viewIndex, locals.DrawParameters, ref renderNode.RenderObject.BoundingBox);
+                        environmentLight.ApplyDrawParameters(pContext, pViewIndex, locals.DrawParameters, ref renderNode.RenderObject.BoundingBox);
                     }
 
                     // Update resources

--- a/sources/engine/Xenko.Rendering/Rendering/Materials/MaterialRenderFeature.cs
+++ b/sources/engine/Xenko.Rendering/Rendering/Materials/MaterialRenderFeature.cs
@@ -112,11 +112,11 @@ namespace Xenko.Rendering.Materials
             {
                 var staticObjectNode = renderObject.StaticObjectNode;
 
-                var renderMesh = (RenderMesh)renderObject;
-                bool resetPipelineState = false;
+                    var renderMesh = (RenderMesh)renderObject;
+                    bool resetPipelineState = false;
 
-                var material = renderMesh.MaterialPass;
-                var materialInfo = renderMesh.MaterialInfo;
+                    var material = renderMesh.MaterialPass;
+                    var materialInfo = renderMesh.MaterialInfo;
 
                 // Material use first 16 bits
                 var materialHashCode = material != null ? ((uint)material.GetHashCode() & 0x0FFF) | ((uint)material.PassIndex << 12) : 0;
@@ -133,15 +133,15 @@ namespace Xenko.Rendering.Materials
                     {
                         tessellationState.Method = material.TessellationMethod;
 
-                        var oldMeshDraw = renderMesh.ActiveMeshDraw;
-                        tessellationMeshDraw = new MeshDraw
-                        {
-                            VertexBuffers = oldMeshDraw.VertexBuffers,
-                            IndexBuffer = oldMeshDraw.IndexBuffer,
-                            DrawCount = oldMeshDraw.DrawCount,
-                            StartLocation = oldMeshDraw.StartLocation,
-                            PrimitiveType = tessellationState.Method.GetPrimitiveType(),
-                        };
+                            var oldMeshDraw = renderMesh.ActiveMeshDraw;
+                            tessellationMeshDraw = new MeshDraw
+                            {
+                                VertexBuffers = oldMeshDraw.VertexBuffers,
+                                IndexBuffer = oldMeshDraw.IndexBuffer,
+                                DrawCount = oldMeshDraw.DrawCount,
+                                StartLocation = oldMeshDraw.StartLocation,
+                                PrimitiveType = tessellationState.Method.GetPrimitiveType(),
+                            };
 
                         // adapt the primitive type and index buffer to the tessellation used
                         if (tessellationState.Method.PerformsAdjacentEdgeAverage())
@@ -155,9 +155,9 @@ namespace Xenko.Rendering.Materials
                         }
                         tessellationState.MeshDraw = tessellationMeshDraw;
 
-                        // Reset pipeline states
-                        resetPipelineState = true;
-                    }
+                            // Reset pipeline states
+                            resetPipelineState = true;
+                        }
 
                     renderMesh.ActiveMeshDraw = tessellationState.MeshDraw;
                 }
@@ -227,12 +227,12 @@ namespace Xenko.Rendering.Materials
                                 materialInfo.HasNormalMap = material.Parameters.Get(MaterialKeys.HasNormalMap);
                                 materialInfo.UsePixelShaderWithDepthPass = material.Parameters.Get(MaterialKeys.UsePixelShaderWithDepthPass);
 
-                                materialInfo.MaterialParameters = material.Parameters;
-                                materialInfo.ParametersChanged = isMaterialParametersChanged;
-                                materialInfo.PermutationCounter = material.Parameters.PermutationCounter;
+                                    materialInfo.MaterialParameters = material.Parameters;
+                                    materialInfo.ParametersChanged = isMaterialParametersChanged;
+                                    materialInfo.PermutationCounter = material.Parameters.PermutationCounter;
+                                }
                             }
                         }
-                    }
 
                     // VS
                     if (materialInfo.VertexStageSurfaceShaders != null)
@@ -281,12 +281,12 @@ namespace Xenko.Rendering.Materials
                 if (renderNode.RenderEffect.State != RenderEffectState.Normal)
                     return;
 
-                // Collect materials and create associated MaterialInfo (includes reflection) first time
-                // TODO: We assume same material will generate same ResourceGroup (i.e. same resources declared in same order)
-                // Need to offer some protection if this invariant is violated (or support it if it can actually happen in real scenario)
-                var material = renderMesh.MaterialPass;
-                var materialInfo = renderMesh.MaterialInfo;
-                var materialParameters = material.Parameters;
+                    // Collect materials and create associated MaterialInfo (includes reflection) first time
+                    // TODO: We assume same material will generate same ResourceGroup (i.e. same resources declared in same order)
+                    // Need to offer some protection if this invariant is violated (or support it if it can actually happen in real scenario)
+                    var material = renderMesh.MaterialPass;
+                    var materialInfo = renderMesh.MaterialInfo;
+                    var materialParameters = material.Parameters;
 
                 // Register resources usage
                 Context.StreamingManager?.StreamResources(materialParameters);

--- a/sources/engine/Xenko.Rendering/Rendering/SkinningRenderFeature.cs
+++ b/sources/engine/Xenko.Rendering/Rendering/SkinningRenderFeature.cs
@@ -51,45 +51,46 @@ namespace Xenko.Rendering
             var renderEffects = RootRenderFeature.RenderData.GetData(renderEffectKey);
             int effectSlotCount = ((RootEffectRenderFeature)RootRenderFeature).EffectPermutationSlotCount;
 
-            //foreach (var objectNodeReference in RootRenderFeature.ObjectNodeReferences)
-            Dispatcher.ForEach(((RootEffectRenderFeature)RootRenderFeature).ObjectNodeReferences, objectNodeReference =>
-            {
-                var objectNode = RootRenderFeature.GetObjectNode(objectNodeReference);
-                var renderMesh = (RenderMesh)objectNode.RenderObject;
-                var staticObjectNode = renderMesh.StaticObjectNode;
-
-                ref var skinningInfo = ref skinningInfos[staticObjectNode];
-                var parameters = renderMesh.Mesh.Parameters;
-                if (parameters != skinningInfo.Parameters || parameters.PermutationCounter != skinningInfo.PermutationCounter)
+            var oNodeRef = ((RootEffectRenderFeature)RootRenderFeature).ObjectNodeReferences;
+            Dispatcher.ForEach(oNodeRef, (@this: this, skinningInfos, renderEffects, effectSlotCount),
+                delegate (ref (SkinningRenderFeature @this, StaticObjectPropertyData<SkinningInfo> skinningInfos, StaticObjectPropertyData<RenderEffect> renderEffects, int effectSlotCount) p, ObjectNodeReference objectNodeReference)
                 {
-                    skinningInfo.Parameters = parameters;
-                    skinningInfo.PermutationCounter = parameters.PermutationCounter;
+                    var objectNode = p.@this.RootRenderFeature.GetObjectNode(objectNodeReference);
+                    var renderMesh = (RenderMesh)objectNode.RenderObject;
+                    var staticObjectNode = renderMesh.StaticObjectNode;
 
-                    skinningInfo.HasSkinningPosition = parameters.Get(MaterialKeys.HasSkinningPosition);
-                    skinningInfo.HasSkinningNormal = parameters.Get(MaterialKeys.HasSkinningNormal);
-                    skinningInfo.HasSkinningTangent = parameters.Get(MaterialKeys.HasSkinningTangent);
-                }
-
-                for (int i = 0; i < effectSlotCount; ++i)
-                {
-                    var staticEffectObjectNode = staticObjectNode * effectSlotCount + i;
-                    var renderEffect = renderEffects[staticEffectObjectNode];
-
-                    // Skip effects not used during this frame
-                    if (renderEffect == null || !renderEffect.IsUsedDuringThisFrame(RenderSystem))
-                        continue;
-
-                    if (renderMesh.Mesh.Skinning != null)
+                    ref var skinningInfo = ref p.skinningInfos[staticObjectNode];
+                    var parameters = renderMesh.Mesh.Parameters;
+                    if (parameters != skinningInfo.Parameters || parameters.PermutationCounter != skinningInfo.PermutationCounter)
                     {
-                        renderEffect.EffectValidator.ValidateParameter(MaterialKeys.HasSkinningPosition, skinningInfo.HasSkinningPosition);
-                        renderEffect.EffectValidator.ValidateParameter(MaterialKeys.HasSkinningNormal, skinningInfo.HasSkinningNormal);
-                        renderEffect.EffectValidator.ValidateParameter(MaterialKeys.HasSkinningTangent, skinningInfo.HasSkinningTangent);
+                        skinningInfo.Parameters = parameters;
+                        skinningInfo.PermutationCounter = parameters.PermutationCounter;
 
-                        var skinningBones = Math.Max(MaxBones, renderMesh.Mesh.Skinning.Bones.Length);
-                        renderEffect.EffectValidator.ValidateParameter(MaterialKeys.SkinningMaxBones, skinningBones);
+                        skinningInfo.HasSkinningPosition = parameters.Get(MaterialKeys.HasSkinningPosition);
+                        skinningInfo.HasSkinningNormal = parameters.Get(MaterialKeys.HasSkinningNormal);
+                        skinningInfo.HasSkinningTangent = parameters.Get(MaterialKeys.HasSkinningTangent);
                     }
-                }
-            });
+
+                    for (int i = 0; i < p.effectSlotCount; ++i)
+                    {
+                        var staticEffectObjectNode = staticObjectNode * p.effectSlotCount + i;
+                        var renderEffect = p.renderEffects[staticEffectObjectNode];
+
+                        // Skip effects not used during this frame
+                        if (renderEffect == null || !renderEffect.IsUsedDuringThisFrame(p.@this.RenderSystem))
+                            continue;
+
+                        if (renderMesh.Mesh.Skinning != null)
+                        {
+                            renderEffect.EffectValidator.ValidateParameter(MaterialKeys.HasSkinningPosition, skinningInfo.HasSkinningPosition);
+                            renderEffect.EffectValidator.ValidateParameter(MaterialKeys.HasSkinningNormal, skinningInfo.HasSkinningNormal);
+                            renderEffect.EffectValidator.ValidateParameter(MaterialKeys.HasSkinningTangent, skinningInfo.HasSkinningTangent);
+
+                            var skinningBones = Math.Max(p.@this.MaxBones, renderMesh.Mesh.Skinning.Bones.Length);
+                            renderEffect.EffectValidator.ValidateParameter(MaterialKeys.SkinningMaxBones, skinningBones);
+                        }
+                    }
+                });
         }
 
         /// <inheritdoc/>
@@ -97,14 +98,15 @@ namespace Xenko.Rendering
         {
             var renderModelObjectInfo = RootRenderFeature.RenderData.GetData(renderModelObjectInfoKey);
 
-            Dispatcher.ForEach(RootRenderFeature.ObjectNodeReferences, objectNodeReference =>
-            {
-                var objectNode = RootRenderFeature.GetObjectNode(objectNodeReference);
-                var renderMesh = (RenderMesh)objectNode.RenderObject;
+            Dispatcher.ForEach(RootRenderFeature.ObjectNodeReferences, (RootRenderFeature, renderModelObjectInfo),
+                delegate (ref (RootRenderFeature RootRenderFeature, ObjectPropertyData<Matrix[]> renderModelObjectInfo) p, ObjectNodeReference objectNodeReference)
+                {
+                    var objectNode = p.RootRenderFeature.GetObjectNode(objectNodeReference);
+                    var renderMesh = (RenderMesh)objectNode.RenderObject;
 
-                // TODO GRAPHICS REFACTOR: Extract copy of matrices
-                renderModelObjectInfo[objectNodeReference] = renderMesh.BlendMatrices;
-            });
+                    // TODO GRAPHICS REFACTOR: Extract copy of matrices
+                    p.renderModelObjectInfo[objectNodeReference] = renderMesh.BlendMatrices;
+                });
         }
 
         /// <inheritdoc/>
@@ -112,27 +114,29 @@ namespace Xenko.Rendering
         {
             var renderModelObjectInfoData = RootRenderFeature.RenderData.GetData(renderModelObjectInfoKey);
 
-            Dispatcher.ForEach(((RootEffectRenderFeature)RootRenderFeature).RenderNodes, (ref RenderNode renderNode) =>
-            {
-                var perDrawLayout = renderNode.RenderEffect.Reflection?.PerDrawLayout;
-                if (perDrawLayout == null)
-                    return;
-
-                var blendMatricesOffset = perDrawLayout.GetConstantBufferOffset(blendMatrices);
-                if (blendMatricesOffset == -1)
-                    return;
-
-                var renderModelObjectInfo = renderModelObjectInfoData[renderNode.RenderObject.ObjectNode];
-                if (renderModelObjectInfo == null)
-                    return;
-
-                var mappedCB = renderNode.Resources.ConstantBuffer.Data + blendMatricesOffset;
-
-                fixed (Matrix* blendMatricesPtr = &renderModelObjectInfo[0])
+            var nodes = ((RootEffectRenderFeature)RootRenderFeature).RenderNodes;
+            Dispatcher.ForEach(nodes, (@this: this, nodes, renderModelObjectInfoData),
+                delegate (ref (SkinningRenderFeature @this, ConcurrentCollector<RenderNode> nodes, ObjectPropertyData<Matrix[]> renderModelObjectInfoData) p, RenderNode renderNode)
                 {
-                    Utilities.CopyMemory(mappedCB, new IntPtr(blendMatricesPtr), renderModelObjectInfo.Length * sizeof(Matrix));
-                }
-            });
+                    var perDrawLayout = renderNode.RenderEffect.Reflection?.PerDrawLayout;
+                    if (perDrawLayout == null)
+                        return;
+
+                    var blendMatricesOffset = perDrawLayout.GetConstantBufferOffset(p.@this.blendMatrices);
+                    if (blendMatricesOffset == -1)
+                        return;
+
+                    var renderModelObjectInfo = p.renderModelObjectInfoData[renderNode.RenderObject.ObjectNode];
+                    if (renderModelObjectInfo == null)
+                        return;
+
+                    var mappedCB = renderNode.Resources.ConstantBuffer.Data + blendMatricesOffset;
+
+                    fixed (Matrix* blendMatricesPtr = &renderModelObjectInfo[0])
+                    {
+                        Utilities.CopyMemory(mappedCB, new IntPtr(blendMatricesPtr), renderModelObjectInfo.Length * sizeof(Matrix));
+                    }
+                });
         }
     }
 }


### PR DESCRIPTION
# PR Details
One day I'll have to stop fiddling with the ``ThreadPool``, but not today !
Greatly reduces allocations of calls to the ``Dispatcher``, overall per frame allocation on phroot's test scene where reduced from 22k to 6k. Also slight increase in performances overall.

I had to change most function signatures to handle those changes, which might force users of ``Dispatcher`` to adapt to those new ones, I'm not sure whether to classify that as a breaking change.

## Related Issue
None.

## Motivation and Context
Performances.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change ? See PR Details (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.