### PR TITLE
GameStudio to suspend game sub-windows when they are hidden in tab control

### DIFF
--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/GameEditor/Services/EditorGameController.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/GameEditor/Services/EditorGameController.cs
@@ -231,6 +231,16 @@ namespace Xenko.Assets.Presentation.AssetEditors.GameEditor.Services
             return true;
         }
 
+        public void OnHideGame()
+        {
+            Game.IsEditorHidden = true;
+        }
+
+        public void OnShowGame()
+        {
+            Game.IsEditorHidden = false;
+        }
+
         public Vector3 GetMousePositionInScene(bool lastRightClick)
         {
             EnsureNotDestroyed();

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/GameEditor/Services/IEditorGameController.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/GameEditor/Services/IEditorGameController.cs
@@ -46,6 +46,16 @@ namespace Xenko.Assets.Presentation.AssetEditors.GameEditor.Services
         Task<bool> CreateScene();
 
         /// <summary>
+        /// Stops the game from rendering and throttle game updates.
+        /// </summary>
+        void OnHideGame();
+
+        /// <summary>
+        /// Resumes the game rendering and updating and .
+        /// </summary>
+        void OnShowGame();
+
+        /// <summary>
         /// Finds the game-side instance corresponding to the part with the given id, if it exists.
         /// </summary>
         /// <param name="partId">The id of the part to look for.</param>

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/GameEditor/ViewModels/GameEditorViewModel.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/GameEditor/ViewModels/GameEditorViewModel.cs
@@ -29,7 +29,7 @@ namespace Xenko.Assets.Presentation.AssetEditors.GameEditor.ViewModels
         {
             Controller = controllerFactory(this);
             CopyErrorToClipboardCommand = new AnonymousCommand(ServiceProvider, CopyErrorToClipboard);
-            ResumeCommand = new AnonymousCommand(ServiceProvider, Resume);
+            ResumeCommand = new AnonymousCommand(ServiceProvider, ResumeFromError);
         }
 
         /// <summary>
@@ -77,6 +77,16 @@ namespace Xenko.Assets.Presentation.AssetEditors.GameEditor.ViewModels
             base.Destroy();
         }
 
+        public void HideGame()
+        {
+            Controller.OnHideGame();
+        }
+
+        public void ShowGame()
+        {
+            Controller.OnShowGame();
+        }
+
         protected virtual async Task<bool> InitializeEditor()
         {
             Dispatcher.EnsureAccess();
@@ -112,7 +122,7 @@ namespace Xenko.Assets.Presentation.AssetEditors.GameEditor.ViewModels
                 SafeClipboard.SetText(log);
         }
 
-        private void Resume()
+        private void ResumeFromError()
         {
             Controller.GetService<IEditorGameRecoveryViewModelService>()?.Resume();
         }

--- a/sources/editor/Xenko.Core.Assets.Editor/Services/IAssetPreviewService.cs
+++ b/sources/editor/Xenko.Core.Assets.Editor/Services/IAssetPreviewService.cs
@@ -13,5 +13,9 @@ namespace Xenko.Core.Assets.Editor.Services
         object GetCurrentPreviewView();
 
         event EventHandler<EventArgs> PreviewAssetUpdated;
+
+        void OnShowPreview();
+
+        void OnHidePreview();
     }
 }

--- a/sources/editor/Xenko.Editor/Preview/GameStudioPreviewService.cs
+++ b/sources/editor/Xenko.Editor/Preview/GameStudioPreviewService.cs
@@ -195,7 +195,7 @@ namespace Xenko.Editor.Preview
         }
 
         public AssetCompilerResult Compile(AssetItem asset)
-        { 
+        {
             return previewCompiler.Prepare(previewCompileContext, asset);
         }
 
@@ -318,6 +318,16 @@ namespace Xenko.Editor.Preview
         public void RegisterAssetPreviewFactories(IReadOnlyDictionary<Type, AssetPreviewFactory> factories)
         {
             factories.ForEach(x => assetPreviewFactories.Add(x.Key, x.Value));
+        }
+
+        public void OnShowPreview()
+        {
+            PreviewGame.IsEditorHidden = false;
+        }
+
+        public void OnHidePreview()
+        {
+            PreviewGame.IsEditorHidden = true;
         }
     }
 }

--- a/sources/editor/Xenko.GameStudio/AssetEditorsManager.cs
+++ b/sources/editor/Xenko.GameStudio/AssetEditorsManager.cs
@@ -313,6 +313,7 @@ namespace Xenko.GameStudio
                         AvalonDockHelper.GetDocumentPane(dockingLayoutManager.DockingManager).Children.Add(editorPane);
                     }
                     editorPane.IsActiveChanged += EditorPaneIsActiveChanged;
+                    editorPane.IsSelectedChanged += EditorPaneIsSelectedChanged;
                     editorPane.Closing += EditorPaneClosing;
                     editorPane.Closed += EditorPaneClosed;
                     editorPane.Content = view;
@@ -495,6 +496,7 @@ namespace Xenko.GameStudio
         private void RemoveEditorPane([NotNull] LayoutAnchorable editorPane)
         {
             editorPane.IsActiveChanged -= EditorPaneIsActiveChanged;
+            editorPane.IsSelectedChanged -= EditorPaneIsSelectedChanged;
             editorPane.Closing -= EditorPaneClosing;
             editorPane.Closed -= EditorPaneClosed;
 
@@ -563,6 +565,29 @@ namespace Xenko.GameStudio
                 else
                 {
                     element.Loaded -= EditorPaneContentLoaded;
+                }
+            }
+        }
+
+        private static void EditorPaneIsSelectedChanged(object sender, EventArgs e)
+        {
+            var editorPane = (LayoutAnchorable)sender;
+            var element = editorPane.Content as FrameworkElement;
+
+            if (element != null)
+            {
+                var assetViewModel = element?.DataContext as AssetViewModel;
+                if (assetViewModel?.Editor is Assets.Presentation.AssetEditors.GameEditor.ViewModels.GameEditorViewModel gameEditor)
+                {
+                    // A tab/sub-window is visible via IsSelected, not IsVisible
+                    if (editorPane.IsSelected)
+                    {
+                        gameEditor.ShowGame();
+                    }
+                    else
+                    {
+                        gameEditor.HideGame();
+                    }
                 }
             }
         }

--- a/sources/editor/Xenko.GameStudio/GameStudioWindow.xaml.cs
+++ b/sources/editor/Xenko.GameStudio/GameStudioWindow.xaml.cs
@@ -24,6 +24,7 @@ using Xenko.Core.Presentation.Extensions;
 using Xenko.Core.Presentation.Interop;
 using Xenko.Core.Presentation.Windows;
 using Xenko.Core.Translation;
+using Xceed.Wpf.AvalonDock.Layout;
 #if DEBUG
 using Xenko.Assets.Presentation.Test;
 #endif
@@ -178,6 +179,33 @@ namespace Xenko.GameStudio
             e.Cancel = true;
             // This method will shutdown the application if the session has been successfully closed.
             SaveAndClose().Forget();
+        }
+
+        internal void RegisterAssetPreview(LayoutAnchorable assetPreviewAnchorable)
+        {
+            // We listen to the events here instead of via xaml because DockingLayoutManager essentially breaks
+            // the entire docking control and OnEventCommandBehavior.CommandParameter binding would not
+            // get restored properly, due to not being able to rebind to a control.
+            assetPreviewAnchorable.IsSelectedChanged += OnAssetPreviewAnchorable_IsSelectedChanged;
+            UpdateAssetPreviewAnchorable(assetPreviewAnchorable);
+        }
+
+        internal void UnregisterAssetPreview(LayoutAnchorable assetPreviewAnchorable)
+        {
+            assetPreviewAnchorable.IsSelectedChanged -= OnAssetPreviewAnchorable_IsSelectedChanged;
+        }
+
+        private void OnAssetPreviewAnchorable_IsSelectedChanged(object sender, EventArgs e)
+        {
+            if (sender is LayoutAnchorable anchorable)
+            {
+                UpdateAssetPreviewAnchorable(anchorable);
+            }
+        }
+
+        private void UpdateAssetPreviewAnchorable(LayoutAnchorable anchorable)
+        {
+            (Editor as GameStudioViewModel)?.Preview?.RenderPreviewCommand?.Execute(anchorable.IsSelected);
         }
 
         private void InitializeWindowSize()

--- a/sources/editor/Xenko.GameStudio/PreviewViewModel.cs
+++ b/sources/editor/Xenko.GameStudio/PreviewViewModel.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Xenko.Core.Assets.Editor.Services;
 using Xenko.Core.Assets.Editor.ViewModel;
 using Xenko.Core.Extensions;
+using Xenko.Core.Presentation.Commands;
 using Xenko.Core.Presentation.ViewModel;
 
 namespace Xenko.GameStudio
@@ -17,14 +18,18 @@ namespace Xenko.GameStudio
 
         private IAssetPreviewService previewService;
         private object previewObject;
-        
+
         public PreviewViewModel(SessionViewModel session)
             : base(session.SafeArgument(nameof(session)).ServiceProvider)
         {
             this.session = session;
             session.ActiveAssetView.SelectedAssets.CollectionChanged += SelectedAssetsCollectionChanged;
             session.ActiveAssetsChanged += ActiveAssetsChanged;
+
+            RenderPreviewCommand = new AnonymousCommand<bool>(session.ServiceProvider, SetIsVisible);
         }
+
+        public CommandBase RenderPreviewCommand { get; }
 
         public object PreviewObject { get { return previewObject; } private set { SetValue(ref previewObject, value); } }
 
@@ -96,6 +101,14 @@ namespace Xenko.GameStudio
             {
                 previewService.SetAssetToPreview(null);
             }
+        }
+
+        private void SetIsVisible(bool isVisible)
+        {
+            if (isVisible)
+                PreviewService.OnShowPreview();
+            else
+                PreviewService.OnHidePreview();
         }
     }
 }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Throttle the game update and prevent draw calls for scene/prefab editors and the preview asset when they are hidden inside a tab in the editor.

## Description

<!--- Describe your changes in detail -->
Added `EditorServiceGame.IsEditorHidden` field to throttle the game updating to once per second, and stop the draw code.

~I tried to keep close to the current architecture.~ (Yeah, I don't think I can claim that anymore...)

A dockable sub-window's visibility can't be detected with `IsVisible`, no idea why...
What's actually required is testing `IsSelected`. This should work whether it's split or floating.
Unfortunately, the Asset Preview sub-window requires a bigger hack, due to `DockingLayoutManager` essentially destroying and recreating the `DockingManager` control. This broke every `<i:Interaction.Behaviors>` inside `DockingManager`, which I've restored however it turns out the bindings are actually broken on all these Behaviors already. This can be investigated and fixed later.

Regarding the Asset Preview sub-window, I wanted to use `OnEventCommandBehavior` in `GameStudioWindow.xaml` instead of using the code behind, but binding to `CommandParameter` requires binding to the `LayoutAnchorable` control (for `IsSelected`), but the fix to the `Behaviors` stated above still doesn't work on it, probably because the binding locks on to 'old' control rather than update itself to 'current' control.

Naming improvements and/or other suggestions to keep it consistent are welcome.


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Scenes/Prefabs/Preview Asset windows continue running/drawing when not visible, which may slow down the Game Studio if too many tabs are open.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.