### PR TITLE
[Threading] Dispatcher scheduling (cont. #562)

### DIFF
--- a/sources/core/Xenko.Core/Threading/ThreadPool.cs
+++ b/sources/core/Xenko.Core/Threading/ThreadPool.cs
@@ -19,18 +19,14 @@ namespace Xenko.Core.Threading
 		/// Low contention for pool threads.
 		/// </summary>
 		private volatile LinkedIdleThread idleThreads;
-		/// <summary>
-		/// Linked-list like collection of work that can be
-		/// de-queued from any thread when they are done working.
-		/// High contention for pool threads.
-		/// </summary>
-		private volatile LinkedWork sharedWorkStack;
+
+		private readonly LightConcurrentQueue<Action> queue = new LightConcurrentQueue<Action>();
 		
 		public ThreadPool()
 		{
 			// Cache delegate to avoid pointless allocation
 			cachedTaskLoop = ProcessWorkItems;
-			// Inconsistent performances when more threads are trying to be woken up than there is processors
+			// No point in having more threads than processors
 			int maxThreads = (Environment.ProcessorCount < 2) ? 1 : (Environment.ProcessorCount - 1);
 			for( int i = 0; i < maxThreads; i++ )
 			{
@@ -48,51 +44,46 @@ namespace Xenko.Core.Threading
 			}.Start(node);
 		}
 		
-		public void QueueWorkItem([NotNull, Pooled] Action workItem)
+		public void QueueWorkItem([NotNull, Pooled] Action workItem, int amount = 1)
 		{
 			// Throw right here to help debugging
 			if(workItem == null)
 			{
 				throw new NullReferenceException(nameof(workItem));
 			}
-			
-			PooledDelegateHelper.AddReference(workItem);
 
-			LinkedWork newSharedNode = null;
-			while(true)
+			if (amount < 1)
 			{
-				// Are all threads busy ?
-				LinkedIdleThread node = idleThreads;
-				if(node == null)
+				throw new ArgumentOutOfRangeException(nameof(amount));
+			}
+			
+			SpinWait sw = new SpinWait();
+			while (amount > 0)
+			{
+				PooledDelegateHelper.AddReference(workItem);
+				LinkedIdleThread node;
+				// Spin a bit to wait for threads
+				while ((node = idleThreads) == null && sw.NextSpinWillYield == false)
 				{
-					if(newSharedNode == null)
-					{
-						newSharedNode = new LinkedWork(workItem);
-						if(idleThreads != null)
-							continue;
-					}
-
-					// Schedule it on the shared stack
-					newSharedNode.Previous = Interlocked.Exchange(ref sharedWorkStack, newSharedNode);
-					newSharedNode.PreviousIsValid = true;
-					break;
-				}
-				// Schedule this work item on latest idle thread
-				
-				while(node.PreviousIsValid == false)
-				{
-					// Spin while invalid, should be extremely short
+					sw.SpinOnce();
 				}
 
-				// Try take this thread
-				if(Interlocked.CompareExchange(ref idleThreads, node.Previous, node) != node)
-					continue; // Latest idle threads changed, try again
-				
-				// Wakeup thread and schedule work
-				// The order those two lines are laid out in is essential !
-				Interlocked.Exchange(ref node.Work, workItem);
-				node.MRE.Set();
-				break;
+				if (node != null)
+				{
+					// Try schedule idle thread
+					if (Interlocked.CompareExchange(ref idleThreads, node.Previous, node) != node)
+						continue; // Latest idle threads changed, try again
+
+					// Wakeup thread and schedule work
+					// The order those two lines are laid out in is essential !
+					Interlocked.Exchange(ref node.Work, workItem);
+					node.MRE.Set();
+				}
+				else
+				{
+					queue.Enqueue(workItem);
+				}
+				amount--;
 			}
 		}
 
@@ -103,66 +94,59 @@ namespace Xenko.Core.Threading
 			LinkedIdleThread node = nodeObj == null ? new LinkedIdleThread(new ManualResetEventSlim(true)) : (LinkedIdleThread)nodeObj;
 			try
 			{
-				while(true)
+				while (true)
 				{
 					Action action;
-					LinkedWork workNode = sharedWorkStack;
-					if(workNode != null)
-					{
-						if(TryTakeFromSharedNonBlocking(out var tempAction, workNode))
-						{
-							action = tempAction;
-						}
-						else
-						{
-							// We have shared work to do but failed to retrieve it, try again
-							continue;
-						}
-					}
-					else
+					if (queue.TryDequeue(out action) == false)
 					{
 						// Should we notify system that this thread is ready to work?
 						// This has to also work for when a thread takes the place of another one when restoring
 						// from an exception for example.
 						// If the mre was set and we took the work, this node definitely is dequeued, re-queue it 
-						if(node.MRE.IsSet && Volatile.Read(ref node.Work) == null)
+						SpinWait sw = new SpinWait();
+						if (node.MRE.IsSet && Volatile.Read(ref node.Work) == null)
 						{
 							// Notify that we're waiting for work
 							node.MRE.Reset();
-							node.PreviousIsValid = false;
-							node.Previous = Interlocked.Exchange(ref idleThreads, node);
-							node.PreviousIsValid = true;
+							while (true)
+							{
+								node.Previous = idleThreads;
+								if (Interlocked.CompareExchange(ref idleThreads, node, node.Previous) == node.Previous)
+								{
+									break;
+								}
+								sw.SpinOnce();
+							}
 						}
-					
+
 						// Wait for work
-						SpinWait sw = new SpinWait();
+						sw = new SpinWait();
 						while (true)
 						{
-							if(node.MRE.IsSet)
+							if (node.MRE.IsSet)
 							{
 								// Work has been scheduled for this thread specifically, take it
 								action = Interlocked.Exchange(ref node.Work, null);
 								break;
 							}
-							if(TryTakeFromSharedNonBlocking(out var tempAction, sharedWorkStack))
+							else if (queue.TryDequeue(out action))
 							{
-								action = tempAction; 
 								break; // We successfully dequeued this node from the shared stack, quit loop and process action
 							}
-						
-							// Wait for work
-							if (sw.NextSpinWillYield)
+							else if (sw.NextSpinWillYield)
 							{
-								// Wait for work to be scheduled specifically to this thread
+								// Spun for enough time, go to sleep and wait for work to be scheduled specifically to this thread
 								node.MRE.Wait();
 								action = Interlocked.Exchange(ref node.Work, null);
 								break;
 							}
-						
-							sw.SpinOnce();
+							else
+							{
+								sw.SpinOnce();
+							}
 						}
 					}
-					
+
 					try
 					{
 						action();
@@ -180,55 +164,195 @@ namespace Xenko.Core.Threading
 				NewThread(node);
 			}
 		}
-		
-		/// <summary>
-		/// Attempt to remove the latest action scheduled on the shared stack,
-		/// returns work only if there was any work AND the item was successfully
-		/// removed from the stack without having to block.
-		/// </summary>
-		bool TryTakeFromSharedNonBlocking(out Action a, LinkedWork nodeToProcess)
-		{
-			if(nodeToProcess != null)
-			{
-				while(nodeToProcess.PreviousIsValid == false)
-				{
-					// Spin while invalid, should be extremely short
-				}
-
-				if(Interlocked.CompareExchange(ref sharedWorkStack, nodeToProcess.Previous, nodeToProcess) == nodeToProcess)
-				{
-					a = nodeToProcess.Work;
-					return true;
-				}
-			}
-
-			a = null;
-			return false;
-		}
 
 		private class LinkedIdleThread
 		{
 			public Action Work;
 			public readonly ManualResetEventSlim MRE;
 			public volatile LinkedIdleThread Previous;
-			public volatile bool PreviousIsValid;
 			
 			public LinkedIdleThread(ManualResetEventSlim MREParam)
 			{
 				MRE = MREParam;
 			}
 		}
-		
-		private class LinkedWork
-		{
-			public readonly Action Work;
-			public volatile LinkedWork Previous;
-			public volatile bool PreviousIsValid;
-			
-			public LinkedWork(Action workParam)
-			{
-				Work = workParam;
-			}
-		}
+
+		/// <summary>
+        /// Standard queue implementation supporting lock-free concurrent reading and writing, blocks r/w when resizing.
+        /// Slower than dotnet's conc-queue but only allocates on resize which is better for more complex program's overall performances.
+        /// </summary>
+        private class LightConcurrentQueue<T> where T : class
+        {
+            private const int INITIAL_SIZE = 4;
+            private T[] array = new T[INITIAL_SIZE];
+            private volatile uint max = INITIAL_SIZE;
+            private int rHead, wHead, count;
+            private int lockState;
+
+            public void Enqueue(T val)
+            {
+                if (val is null)
+                    throw new ArgumentNullException(nameof(val));
+
+                do
+                {
+	                int size;
+	                try
+	                {
+		                PreventResizeLock();
+
+		                size = array.Length;
+
+		                var i = ((uint)Interlocked.Increment(ref wHead) - 1) % (uint)size;
+		                if (Interlocked.CompareExchange(ref array[i], val, null) == null)
+		                {
+			                Interlocked.Increment(ref count);
+			                return;
+		                }
+
+		                // If non-null it hasn't been dequeued yet we need to grow this array.
+		                // Release lock then AttemptGrow.
+	                }
+	                finally
+	                {
+		                ReleaseLock();
+	                }
+
+	                AttemptGrow(size);
+                } while (true);
+            }
+            
+            public bool TryDequeue(out T output)
+            {
+                var sw = new SpinWait();
+                
+                // Remove one from count if there is any left,
+                // guarantees that increasing the head and taking the item is a valid operation
+                do
+                {
+                    int v = count;
+                    if (v == 0)
+                    {
+                        output = default;
+                        return false;
+                    }
+                    // Spinning right before comp-exchange improves performances by a lot,
+                    // not exactly sure why as I tested cases with spinning:
+                    // 'after compxchg', 'after compxchg' + 'when v == 0', 'before rwLock xchg'
+                    // and none of those cases, which have a fairly evident explanation,
+                    // demonstrate such a large increase in performances.
+                    sw.SpinOnce();
+                    if (Interlocked.CompareExchange(ref count, v - 1, v) == v)
+                        break;
+                } while (true);
+
+                try
+                {
+                    PreventResizeLock();
+                    
+                    // We are guaranteed to have at least one item as we decreased count above
+                    var i = ((uint) Interlocked.Increment(ref rHead) - 1) % max;
+                    while ((output = Interlocked.Exchange(ref array[i], null)) == null)
+                    {
+                        // Most cases won't run the spinwait
+                        sw.SpinOnce();
+                    }
+
+                    return true;
+                }
+                finally
+                {
+                    ReleaseLock();
+                }
+            }
+            
+            private void PreventResizeLock()
+            {
+                var sw = new SpinWait();
+                while (Interlocked.Increment(ref lockState) < 0)
+                {
+                    Interlocked.Decrement(ref lockState);
+                    while(Volatile.Read(ref lockState) < 0)
+                        sw.SpinOnce();
+                }
+            }
+            
+            private void ReleaseLock()
+            {
+                Interlocked.Decrement(ref lockState);
+            }
+            
+            private void AttemptGrow(int previousSize)
+            {
+                // Add some padding to avoid wrapping around when we comp-exchange before a thread decreases the lock state
+                // I highly doubt any computer running this logic will ever grow past half int.MaxValue threads
+                const int offset = (int.MaxValue/2);
+                
+                SpinWait sw = new SpinWait();
+                // Prevent multiple resize by ensuring that the lock is positive before negating
+                do
+                {
+                    int v = lockState;
+                    if (v < 0)
+                        return; // Another thread is already attempting to grow, exit
+                    
+                    if (Interlocked.CompareExchange(ref lockState, v - offset, v) == v)
+                        break; // We're blocking all new read and write now
+                    
+                    if(previousSize != max)
+                        return;
+                    
+                    sw.SpinOnce();
+                } while (true);
+                
+                try
+                {
+                    // lockState is now negative
+                    
+                    // Let's wait for other threads to exit the lock before resizing 
+                    while (Volatile.Read(ref lockState) != -offset)
+                    {
+                        sw.SpinOnce();
+                    }
+
+                    // lockState is still being manipulated by reader and writer but BlockUntilResizeFinished
+                    // prevents them from reading or writing to the array beyond this point.
+                
+                    if(previousSize != max)
+                        return;
+
+                    // Double the size to keep '% array.Length' from creating bad sequences when heads are near uint.MaxValue
+                    T[] newArray = new T[max * 2];
+
+                    var oldMax = max;
+                    var readHead = ((uint) Volatile.Read(ref rHead)) % oldMax;
+                    uint length = oldMax - readHead;
+                    // Place all items after head at the start of the new array
+                    Array.Copy(array, readHead, newArray, 0, length);
+                    if (readHead != 0)
+                    {
+                        // Move all items from 0 to writeHead at the end of the array
+                        Array.Copy(array, 0, newArray, length, readHead);
+                    }
+
+                    max = (uint)newArray.Length;
+                    Interlocked.Exchange(ref array, newArray);
+                    Interlocked.Exchange(ref rHead, 0);
+                    for (int i = 0; i < newArray.Length; i++)
+                    {
+                        if (newArray[i] == null)
+                        {
+                            Interlocked.Exchange(ref wHead, i);
+                            break;
+                        }
+                    }
+                }
+                finally
+                {
+                    // reset the lock to its previous state: unlocked
+                    Interlocked.Add(ref lockState, offset);
+                }
+            }
+        }
     }
 }

--- a/sources/core/Xenko.Core/Threading/ThreadPool.cs
+++ b/sources/core/Xenko.Core/Threading/ThreadPool.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Xenko contributors (https://xenko.com) and Silicon Studio Corp. (https://www.siliconstudio.co.jp)
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
+using System.Collections.Concurrent;
 using System.Threading;
 using Xenko.Core.Annotations;
 
@@ -12,38 +13,23 @@ namespace Xenko.Core.Threading
     internal class ThreadPool
     {
         public static readonly ThreadPool Instance = new ThreadPool();
-		private readonly ParameterizedThreadStart cachedTaskLoop;
-		private readonly bool ManyCore;
         
-		/// <summary>
-		/// Linked-list like collection of threads that are waiting for work.
-		/// Low contention for pool threads.
-		/// </summary>
-		private volatile LinkedIdleThread idleThreads;
+		private readonly ParameterizedThreadStart cachedTaskLoop;
+		private readonly ConcurrentQueue<Action> queue = new ConcurrentQueue<Action>();
+		private readonly object lockObj = new object();
+		
+		private int idleCount;
+		private int itemCount;
 
-		private readonly LightConcurrentQueue<Action> queue = new LightConcurrentQueue<Action>();
-
-		public ThreadPool()
+        public ThreadPool()
 		{
 			// Cache delegate to avoid pointless allocation
 			cachedTaskLoop = ProcessWorkItems;
-			// No point in having more threads than processors
-			int maxThreads = (Environment.ProcessorCount < 2) ? 1 : (Environment.ProcessorCount - 1);
-			ManyCore = maxThreads >= 8;
-			for( int i = 0; i < maxThreads; i++ )
-			{
-				NewThread(null);
+			var threads = Environment.ProcessorCount > 2 ? Environment.ProcessorCount / 2 : 1;
+			for(int i = 0; i < threads; i++)
+            {
+				NewThread();
 			}
-		}
-		
-		void NewThread(LinkedIdleThread node)
-		{
-			new Thread(cachedTaskLoop)
-			{
-				Name = $"{GetType().FullName} thread",
-				IsBackground = true,
-				Priority = ThreadPriority.Highest
-			}.Start(node);
 		}
 		
 		public void QueueWorkItem([NotNull, Pooled] Action workItem, int amount = 1)
@@ -54,109 +40,78 @@ namespace Xenko.Core.Threading
 				throw new NullReferenceException(nameof(workItem));
 			}
 
-			if (amount < 1)
+			if(amount < 1)
 			{
 				throw new ArgumentOutOfRangeException(nameof(amount));
 			}
+
+			Interlocked.Add(ref itemCount, amount);
 			
-			SpinWait sw = new SpinWait();
-			while (amount > 0)
+			for(int i = 0; i < amount; i++)
 			{
 				PooledDelegateHelper.AddReference(workItem);
-				LinkedIdleThread node;
-				if (ManyCore)
-				{
-					// Spin a bit to wait for threads
-					while ((node = idleThreads) == null && sw.NextSpinWillYield == false)
-					{
-						sw.SpinOnce();
-					}
-				}
-				else
-				{
-					node = idleThreads;
-				}
-
-
-				if (node != null)
-				{
-					// Try schedule idle thread
-					if (Interlocked.CompareExchange(ref idleThreads, node.Previous, node) != node)
-						continue; // Latest idle threads changed, try again
-
-					// Wakeup thread and schedule work
-					// The order those two lines are laid out in is essential !
-					Interlocked.Exchange(ref node.Work, workItem);
-					node.MRE.Set();
-				}
-				else
-				{
-					queue.Enqueue(workItem);
-				}
-				amount--;
+				queue.Enqueue(workItem);
+			}
+			
+			if(Volatile.Read(ref idleCount) == 0)
+				return;
+			
+			lock(lockObj)
+			{
+				if(Volatile.Read(ref idleCount) == 0)
+					return;
+				
+				Monitor.Pulse(lockObj);
 			}
 		}
 
-		private void ProcessWorkItems(object nodeObj)
+		private void ProcessWorkItems(object paramObj)
 		{
-			// nodeObj is non-null when a thread caught an exception and had to throw,
-			// the thread created another one and passed its node obj to us.
-			LinkedIdleThread node = nodeObj == null ? new LinkedIdleThread(new ManualResetEventSlim(true)) : (LinkedIdleThread)nodeObj;
 			try
 			{
-				while (true)
+				while(true)
 				{
 					Action action;
-					if (queue.TryDequeue(out action) == false)
+					var sw = new SpinWait();
+					while(true)
 					{
-						// Should we notify system that this thread is ready to work?
-						// This has to also work for when a thread takes the place of another one when restoring
-						// from an exception for example.
-						// If the mre was set and we took the work, this node definitely is dequeued, re-queue it 
-						SpinWait sw = new SpinWait();
-						if (node.MRE.IsSet && Volatile.Read(ref node.Work) == null)
+						if(queue.TryDequeue(out action))
 						{
-							// Notify that we're waiting for work
-							node.MRE.Reset();
-							while (true)
-							{
-								node.Previous = idleThreads;
-								if (Interlocked.CompareExchange(ref idleThreads, node, node.Previous) == node.Previous)
-								{
-									break;
-								}
-								sw.SpinOnce();
-							}
+							break;
 						}
 
-						// Wait for work
-						sw = new SpinWait();
-						while (true)
+						if(Volatile.Read(ref itemCount) == 0)
 						{
-							if (node.MRE.IsSet)
+							if(sw.NextSpinWillYield)
 							{
-								// Work has been scheduled for this thread specifically, take it
-								action = Interlocked.Exchange(ref node.Work, null);
-								break;
-							}
-							else if (queue.TryDequeue(out action))
-							{
-								break; // We successfully dequeued this node from the shared stack, quit loop and process action
-							}
-							else if (sw.NextSpinWillYield)
-							{
-								// Spun for enough time, go to sleep and wait for work to be scheduled specifically to this thread
-								node.MRE.Wait();
-								action = Interlocked.Exchange(ref node.Work, null);
-								break;
+								bool reset = false;
+								lock(lockObj)
+								{
+									if(Volatile.Read(ref itemCount) == 0)
+									{
+										Interlocked.Increment(ref idleCount);
+										Monitor.Wait(lockObj);
+										// We've got work to deal with, pulse other threads
+										Monitor.Pulse(lockObj);
+										reset = true;
+									}
+								}
+
+								if(reset)
+								{
+									Interlocked.Decrement(ref idleCount);
+									sw = new SpinWait();
+								}
 							}
 							else
 							{
+								// Spin for a while to catch more incoming work 
 								sw.SpinOnce();
 							}
 						}
 					}
 
+					Interlocked.Decrement(ref itemCount);
 					try
 					{
 						action();
@@ -170,199 +125,19 @@ namespace Xenko.Core.Threading
 			finally
 			{
 				// We must keep up the amount of threads that the system handles.
-				// Spawn a new one as this one is about to abort because of an exception. 
-				NewThread(node);
+				// Spawn a new one as this one is about to abort because of an exception.
+				NewThread();
 			}
 		}
-
-		private class LinkedIdleThread
+		
+		void NewThread()
 		{
-			public Action Work;
-			public readonly ManualResetEventSlim MRE;
-			public volatile LinkedIdleThread Previous;
-			
-			public LinkedIdleThread(ManualResetEventSlim MREParam)
+			new Thread(cachedTaskLoop)
 			{
-				MRE = MREParam;
-			}
+				Name = $"{GetType().FullName} thread",
+				IsBackground = true,
+				Priority = ThreadPriority.Highest
+			}.Start();
 		}
-
-		/// <summary>
-        /// Standard queue implementation supporting lock-free concurrent reading and writing, blocks r/w when resizing.
-        /// Slower than dotnet's conc-queue but only allocates on resize which is better for more complex program's overall performances.
-        /// </summary>
-        private class LightConcurrentQueue<T> where T : class
-        {
-            private const int INITIAL_SIZE = 4;
-            private T[] array = new T[INITIAL_SIZE];
-            private volatile uint max = INITIAL_SIZE;
-            private int rHead, wHead, count;
-            private int lockState;
-
-            public void Enqueue(T val)
-            {
-                if (val is null)
-                    throw new ArgumentNullException(nameof(val));
-
-                do
-                {
-	                int size;
-	                try
-	                {
-		                PreventResizeLock();
-
-		                size = array.Length;
-
-		                var i = ((uint)Interlocked.Increment(ref wHead) - 1) % (uint)size;
-		                if (Interlocked.CompareExchange(ref array[i], val, null) == null)
-		                {
-			                Interlocked.Increment(ref count);
-			                return;
-		                }
-
-		                // If non-null it hasn't been dequeued yet we need to grow this array.
-		                // Release lock then AttemptGrow.
-	                }
-	                finally
-	                {
-		                ReleaseLock();
-	                }
-
-	                AttemptGrow(size);
-                } while (true);
-            }
-            
-            public bool TryDequeue(out T output)
-            {
-                var sw = new SpinWait();
-                
-                // Remove one from count if there is any left,
-                // guarantees that increasing the head and taking the item is a valid operation
-                do
-                {
-                    int v = count;
-                    if (v == 0)
-                    {
-                        output = default;
-                        return false;
-                    }
-                    // Spinning right before comp-exchange improves performances by a lot,
-                    // not exactly sure why as I tested cases with spinning:
-                    // 'after compxchg', 'after compxchg' + 'when v == 0', 'before rwLock xchg'
-                    // and none of those cases, which have a fairly evident explanation,
-                    // demonstrate such a large increase in performances.
-                    sw.SpinOnce();
-                    if (Interlocked.CompareExchange(ref count, v - 1, v) == v)
-                        break;
-                } while (true);
-
-                try
-                {
-                    PreventResizeLock();
-                    
-                    // We are guaranteed to have at least one item as we decreased count above
-                    var i = ((uint) Interlocked.Increment(ref rHead) - 1) % max;
-                    while ((output = Interlocked.Exchange(ref array[i], null)) == null)
-                    {
-                        // Most cases won't run the spinwait
-                        sw.SpinOnce();
-                    }
-
-                    return true;
-                }
-                finally
-                {
-                    ReleaseLock();
-                }
-            }
-            
-            private void PreventResizeLock()
-            {
-                var sw = new SpinWait();
-                while (Interlocked.Increment(ref lockState) < 0)
-                {
-                    Interlocked.Decrement(ref lockState);
-                    while(Volatile.Read(ref lockState) < 0)
-                        sw.SpinOnce();
-                }
-            }
-            
-            private void ReleaseLock()
-            {
-                Interlocked.Decrement(ref lockState);
-            }
-            
-            private void AttemptGrow(int previousSize)
-            {
-                // Add some padding to avoid wrapping around when we comp-exchange before a thread decreases the lock state
-                // I highly doubt any computer running this logic will ever grow past half int.MaxValue threads
-                const int offset = (int.MaxValue/2);
-                
-                SpinWait sw = new SpinWait();
-                // Prevent multiple resize by ensuring that the lock is positive before negating
-                do
-                {
-                    int v = lockState;
-                    if (v < 0)
-                        return; // Another thread is already attempting to grow, exit
-                    
-                    if (Interlocked.CompareExchange(ref lockState, v - offset, v) == v)
-                        break; // We're blocking all new read and write now
-                    
-                    if(previousSize != max)
-                        return;
-                    
-                    sw.SpinOnce();
-                } while (true);
-                
-                try
-                {
-                    // lockState is now negative
-                    
-                    // Let's wait for other threads to exit the lock before resizing 
-                    while (Volatile.Read(ref lockState) != -offset)
-                    {
-                        sw.SpinOnce();
-                    }
-
-                    // lockState is still being manipulated by reader and writer but BlockUntilResizeFinished
-                    // prevents them from reading or writing to the array beyond this point.
-                
-                    if(previousSize != max)
-                        return;
-
-                    // Double the size to keep '% array.Length' from creating bad sequences when heads are near uint.MaxValue
-                    T[] newArray = new T[max * 2];
-
-                    var oldMax = max;
-                    var readHead = ((uint) Volatile.Read(ref rHead)) % oldMax;
-                    uint length = oldMax - readHead;
-                    // Place all items after head at the start of the new array
-                    Array.Copy(array, readHead, newArray, 0, length);
-                    if (readHead != 0)
-                    {
-                        // Move all items from 0 to writeHead at the end of the array
-                        Array.Copy(array, 0, newArray, length, readHead);
-                    }
-
-                    max = (uint)newArray.Length;
-                    Interlocked.Exchange(ref array, newArray);
-                    Interlocked.Exchange(ref rHead, 0);
-                    for (int i = 0; i < newArray.Length; i++)
-                    {
-                        if (newArray[i] == null)
-                        {
-                            Interlocked.Exchange(ref wHead, i);
-                            break;
-                        }
-                    }
-                }
-                finally
-                {
-                    // reset the lock to its previous state: unlocked
-                    Interlocked.Add(ref lockState, offset);
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
# PR Details
This is a second attempt to implement some of #562 features, the logic implemented to reduce allocations from that PR has not been transferred over to this one, see the discussion [here](https://github.com/stride3d/xenko/pull/562#issuecomment-594200461) for more info.

## Description
- ThreadPool: Remove the last couple of allocations that the internal 'queue' might create when scheduling work.
- Dispatcher: Schedule work for other threads sooner and in bulk.
- Dispatcher: Continue through the frame as soon as work as been completed instead of waiting for other threads to wake up and signal before continuing even though there aren't any work left for them to deal with.

## Related Issue
None.

## Motivation and Context
Performances.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Note:
Previously the PR also took care of refactoring the dispatcher's logic into something more maintainable, less logic duplication etc. I couldn't handle that as doing so would prevent the ``DispatchProcessor`` in its current state from caching delegates. I/We'll take care of the rest once the issues with the ``DispatchProcessor`` have been taken care of.