### PR TITLE
Fix Game Studio adding duplicate asset templates

### DIFF
--- a/sources/assets/Xenko.Core.Assets/Templates/TemplateManager.cs
+++ b/sources/assets/Xenko.Core.Assets/Templates/TemplateManager.cs
@@ -59,7 +59,12 @@ namespace Xenko.Core.Assets.Templates
         /// <returns>A sequence containing all registered template descriptions.</returns>
         public static IEnumerable<TemplateDescription> FindTemplates(PackageSession session = null)
         {
-            var packages = session?.Packages.Concat(ExtraPackages) ?? ExtraPackages;
+            IEnumerable<Package> packages = session?.Packages ?? ExtraPackages;
+            if (packages != ExtraPackages)
+            {
+                var extraPackages = ExtraPackages.Where(x => !packages.Any(sessionPkg => sessionPkg.FullPath == x.FullPath)).ToArray();
+                packages = packages.Concat(extraPackages);
+            }
             // TODO this will not work if the same package has different versions
             return packages.SelectMany(package => package.Templates).OrderBy(tpl => tpl.Order).ThenBy(tpl => tpl.Name).ToList();
         }

--- a/sources/assets/Xenko.Core.Assets/Templates/TemplateManager.cs
+++ b/sources/assets/Xenko.Core.Assets/Templates/TemplateManager.cs
@@ -59,12 +59,7 @@ namespace Xenko.Core.Assets.Templates
         /// <returns>A sequence containing all registered template descriptions.</returns>
         public static IEnumerable<TemplateDescription> FindTemplates(PackageSession session = null)
         {
-            IEnumerable<Package> packages = session?.Packages ?? ExtraPackages;
-            if (packages != ExtraPackages)
-            {
-                var extraPackages = ExtraPackages.Where(x => !packages.Any(sessionPkg => sessionPkg.FullPath == x.FullPath)).ToArray();
-                packages = packages.Concat(extraPackages);
-            }
+            var packages = session?.Packages.Concat(ExtraPackages).Distinct(DistinctPackagePathComparer.Default) ?? ExtraPackages;
             // TODO this will not work if the same package has different versions
             return packages.SelectMany(package => package.Templates).OrderBy(tpl => tpl.Order).ThenBy(tpl => tpl.Name).ToList();
         }
@@ -122,6 +117,30 @@ namespace Xenko.Core.Assets.Templates
                 }
             }
             return null;
+        }
+
+        private class DistinctPackagePathComparer : IEqualityComparer<Package>
+        {
+            private static DistinctPackagePathComparer defaultInstance;
+            public static DistinctPackagePathComparer Default
+            {
+                get
+                {
+                    if (defaultInstance == null)
+                        defaultInstance = new DistinctPackagePathComparer();
+                    return defaultInstance;
+                }
+            }
+
+            public bool Equals(Package x, Package y)
+            {
+                return x.FullPath == y.FullPath;
+            }
+
+            public int GetHashCode(Package obj)
+            {
+                return obj.FullPath.GetHashCode();
+            }
         }
     }
 }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Fixes a special case where I have explicitly included a Xenko package in my project, and Game Studio adds its own packages (in `ExtraPackages`) causing duplicate templates to appear (in the 'Add Asset' menu).

## Description

<!--- Describe your changes in detail -->
This change checks if any of the `ExtraPackage`s is already defined in the current session's packages and ignores re-adding them.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The truth is that all I want is access to `GizmoComponentAttribute` and `EntityGizmo` so that I can get my custom components in Game Studio to be clickable within the scene, but currently this requires referencing `Xenko.Assets.Presentation` to get to these classes, and I'm not really willing to make any massive changes to get this to work.
`ExtraPackages` also defines `Xenko.Assets.Presentation` so the concatenation duplicates the asset templates.

I'm aware this is more of a hidden "feature" so feel free to reject this pull.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.