### PR TITLE
Yet another minor perf improvement pull

### DIFF
--- a/sources/core/Xenko.Core.Mathematics/BoundingFrustum.cs
+++ b/sources/core/Xenko.Core.Mathematics/BoundingFrustum.cs
@@ -47,46 +47,52 @@ namespace Xenko.Core.Mathematics
         public BoundingFrustum(ref Matrix matrix)
         {
             // Left
-            LeftPlane = Plane.Normalize(new Plane(
+            Plane.Normalize(
                 matrix.M14 + matrix.M11,
                 matrix.M24 + matrix.M21,
                 matrix.M34 + matrix.M31,
-                matrix.M44 + matrix.M41));
+                matrix.M44 + matrix.M41,
+                out LeftPlane);
 
             // Right
-            RightPlane = Plane.Normalize(new Plane(
+            Plane.Normalize(
                 matrix.M14 - matrix.M11,
                 matrix.M24 - matrix.M21,
                 matrix.M34 - matrix.M31,
-                matrix.M44 - matrix.M41));
+                matrix.M44 - matrix.M41,
+                out RightPlane);
 
             // Top
-            TopPlane = Plane.Normalize(new Plane(
+            Plane.Normalize(
                 matrix.M14 - matrix.M12,
                 matrix.M24 - matrix.M22,
                 matrix.M34 - matrix.M32,
-                matrix.M44 - matrix.M42));
+                matrix.M44 - matrix.M42,
+                out TopPlane);
 
             // Bottom
-            BottomPlane = Plane.Normalize(new Plane(
+            Plane.Normalize(
                 matrix.M14 + matrix.M12,
                 matrix.M24 + matrix.M22,
                 matrix.M34 + matrix.M32,
-                matrix.M44 + matrix.M42));
+                matrix.M44 + matrix.M42,
+                out BottomPlane);
 
             // Near
-            NearPlane = Plane.Normalize(new Plane(
+            Plane.Normalize(
                 matrix.M13,
                 matrix.M23,
                 matrix.M33,
-                matrix.M43));
+                matrix.M43,
+                out NearPlane);
 
             // Far
-            FarPlane = Plane.Normalize(new Plane(
+            Plane.Normalize(
                 matrix.M14 - matrix.M13,
                 matrix.M24 - matrix.M23,
                 matrix.M34 - matrix.M33,
-                matrix.M44 - matrix.M43));
+                matrix.M44 - matrix.M43,
+                out FarPlane);
         }
 
         /// <summary>

--- a/sources/core/Xenko.Core.Mathematics/Color.cs
+++ b/sources/core/Xenko.Core.Mathematics/Color.cs
@@ -44,16 +44,18 @@ namespace Xenko.Core.Mathematics
         /// <param name="value">The value that will be assigned to all components.</param>
         public Color(byte value)
         {
-            A = R = G = B = value;
+            R = value;
+            G = value;
+            B = value;
+            A = value;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Color"/> struct.
         /// </summary>
         /// <param name="value">The value that will be assigned to all components.</param>
-        public Color(float value)
+        public Color(float value) : this(ToByte(value))
         {
-            A = R = G = B = ToByte(value);
         }
 
         /// <summary>

--- a/sources/core/Xenko.Core.Mathematics/Color4.cs
+++ b/sources/core/Xenko.Core.Mathematics/Color4.cs
@@ -82,7 +82,10 @@ namespace Xenko.Core.Mathematics
         /// <param name="value">The value that will be assigned to all components.</param>
         public Color4(float value)
         {
-            A = R = G = B = value;
+            R = value;
+            G = value;
+            B = value;
+            A = value;
         }
 
         /// <summary>

--- a/sources/core/Xenko.Core.Mathematics/ColorBGRA.cs
+++ b/sources/core/Xenko.Core.Mathematics/ColorBGRA.cs
@@ -46,16 +46,18 @@ namespace Xenko.Core.Mathematics
         /// <param name="value">The value that will be assigned to all components.</param>
         public ColorBGRA(byte value)
         {
-            A = R = G = B = value;
+            B = value;
+            G = value;
+            R = value;
+            A = value;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ColorBGRA"/> struct.
         /// </summary>
         /// <param name="value">The value that will be assigned to all components.</param>
-        public ColorBGRA(float value)
+        public ColorBGRA(float value) : this(ToByte(value))
         {
-            A = R = G = B = ToByte(value);
         }
 
         /// <summary>

--- a/sources/core/Xenko.Core.Mathematics/Plane.cs
+++ b/sources/core/Xenko.Core.Mathematics/Plane.cs
@@ -80,8 +80,8 @@ namespace Xenko.Core.Mathematics
         /// <param name="normal">The normal vector to the plane.</param>
         public Plane(Vector3 point, Vector3 normal)
         {
-            this.Normal = normal;
-            this.D = Vector3.Dot(normal, point);
+            Normal = normal;
+            Vector3.Dot(ref normal, ref point, out D);
         }
 
         /// <summary>
@@ -427,6 +427,24 @@ namespace Xenko.Core.Mathematics
         }
 
         /// <summary>
+        /// Creates a plane of unit length.
+        /// </summary>
+        /// <param name="normalX">The X component of the normal.</param>
+        /// <param name="normalY">The Y component of the normal.</param>
+        /// <param name="normalZ">The Z component of the normal.</param>
+        /// <param name="planeD">The distance of the plane along its normal from the origin.</param>
+        /// <param name="result">When the method completes, contains the normalized plane.</param>
+        public static void Normalize(float normalX, float normalY, float normalZ, float planeD, out Plane result)
+        {
+            float magnitude = 1.0f / (float)(Math.Sqrt((normalX * normalX) + (normalY * normalY) + (normalZ * normalZ)));
+
+            result.Normal.X = normalX * magnitude;
+            result.Normal.Y = normalY * magnitude;
+            result.Normal.Z = normalZ * magnitude;
+            result.D = planeD * magnitude;
+        }
+
+        /// <summary>
         /// Changes the coefficients of the normal vector of the plane to make it of unit length.
         /// </summary>
         /// <param name="plane">The source plane.</param>
@@ -753,7 +771,7 @@ namespace Xenko.Core.Mathematics
         /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
         /// </returns>
         public override int GetHashCode()
         {

--- a/sources/editor/Xenko.Assets.Presentation/AssetEditors/UIEditor/Game/UILayoutHelper.cs
+++ b/sources/editor/Xenko.Assets.Presentation/AssetEditors/UIEditor/Game/UILayoutHelper.cs
@@ -155,16 +155,19 @@ namespace Xenko.Assets.Presentation.AssetEditors.UIEditor.Game
                 var grid = parent as Grid;
                 if (grid != null)
                 {
+                    var actualColumnDefinitions = grid.ActualColumnDefinitions;
+                    var actualRowDefinitions = grid.ActualRowDefinitions;
+
                     var accWidth = 0.0f;
-                    for (var i = 0; i < colIndex && i < grid.ActualColumnDefinitions.Count; i++)
+                    for (var i = 0; i < colIndex && i < actualColumnDefinitions.Count; i++)
                     {
-                        var definition = grid.ActualColumnDefinitions[i];
+                        var definition = actualColumnDefinitions[i];
                         accWidth += definition.ActualSize;
                     }
                     var accHeight = 0.0f;
-                    for (var i = 0; i < rowIndex && i < grid.ActualRowDefinitions.Count; i++)
+                    for (var i = 0; i < rowIndex && i < actualRowDefinitions.Count; i++)
                     {
-                        var definition = grid.ActualRowDefinitions[i];
+                        var definition = actualRowDefinitions[i];
                         accHeight += definition.ActualSize;
                     }
                     rects.Parent = new RectangleF
@@ -172,15 +175,15 @@ namespace Xenko.Assets.Presentation.AssetEditors.UIEditor.Game
                         X = -accWidth, Y = -accHeight, Width = parent.ActualWidth, Height = parent.ActualHeight,
                     };
                     accWidth = 0.0f;
-                    for (var i = colIndex; i < colIndex + colSpan && i < grid.ActualColumnDefinitions.Count; i++)
+                    for (var i = colIndex; i < colIndex + colSpan && i < actualColumnDefinitions.Count; i++)
                     {
-                        var definition = grid.ActualColumnDefinitions[i];
+                        var definition = actualColumnDefinitions[i];
                         accWidth += definition.ActualSize;
                     }
                     accHeight = 0.0f;
-                    for (var i = rowIndex; i < rowIndex + rowSpan && i < grid.ActualRowDefinitions.Count; i++)
+                    for (var i = rowIndex; i < rowIndex + rowSpan && i < actualRowDefinitions.Count; i++)
                     {
-                        var definition = grid.ActualRowDefinitions[i];
+                        var definition = actualRowDefinitions[i];
                         accHeight += definition.ActualSize;
                     }
                     rects.Container = new RectangleF

--- a/sources/engine/Xenko.Graphics/OpenGL/PipelineState.OpenGL.cs
+++ b/sources/engine/Xenko.Graphics/OpenGL/PipelineState.OpenGL.cs
@@ -101,7 +101,7 @@ namespace Xenko.Graphics
             base.OnDestroyed();
         }
 
-        struct VertexAttribsKey
+        struct VertexAttribsKey : IEquatable<VertexAttribsKey>
         {
             public VertexAttrib[] Attribs;
             public int Hash;

--- a/sources/engine/Xenko.Graphics/Sprite3DBatch.cs
+++ b/sources/engine/Xenko.Graphics/Sprite3DBatch.cs
@@ -71,7 +71,7 @@ namespace Xenko.Graphics
                 throw new ArgumentNullException("texture");
 
             // Skip items with null size
-            if (elementSize.Length() < MathUtil.ZeroTolerance)
+            if (elementSize.LengthSquared() < MathUtil.ZeroTolerance)
                 return;
 
             // Calculate the information needed to draw.

--- a/sources/engine/Xenko.Graphics/SpriteFont.cs
+++ b/sources/engine/Xenko.Graphics/SpriteFont.cs
@@ -269,7 +269,7 @@ namespace Xenko.Graphics
             var elementSize = new Vector2(
                 auxiliaryScaling.X * glyph.Subrect.Width / realVirtualResolutionRatio.X,
                 auxiliaryScaling.Y * glyph.Subrect.Height / realVirtualResolutionRatio.Y);
-            if (elementSize.Length() < MathUtil.ZeroTolerance) 
+            if (elementSize.LengthSquared() < MathUtil.ZeroTolerance) 
                 return;
 
             var xShift = x;

--- a/sources/engine/Xenko.Graphics/UIBatch.cs
+++ b/sources/engine/Xenko.Graphics/UIBatch.cs
@@ -215,7 +215,7 @@ namespace Xenko.Graphics
         public void DrawRectangle(ref Matrix worldMatrix, ref Vector3 elementSize, ref Color color, int depthBias)
         {
             // Skip items with null size
-            if (elementSize.Length() < MathUtil.ZeroTolerance)
+            if (elementSize.LengthSquared() < MathUtil.ZeroTolerance)
                 return;
 
             // Calculate the information needed to draw.
@@ -277,7 +277,7 @@ namespace Xenko.Graphics
         private void DrawCube(ref Matrix worldMatrix, ref Vector3 elementSize, ref Color color, int depthBias, bool isReverse)
         {
             // Skip items with null size
-            if (elementSize.Length() < MathUtil.ZeroTolerance)
+            if (elementSize.LengthSquared() < MathUtil.ZeroTolerance)
                 return;
 
             // Calculate the information needed to draw.
@@ -331,7 +331,7 @@ namespace Xenko.Graphics
             if (texture == null) throw new ArgumentNullException(nameof(texture));
 
             // Skip items with null size
-            if (elementSize.Length() < MathUtil.ZeroTolerance)
+            if (elementSize.LengthSquared() < MathUtil.ZeroTolerance)
                 return;
 
             // Calculate the information needed to draw.

--- a/sources/engine/Xenko.Physics/Shapes/StaticPlaneColliderShape.cs
+++ b/sources/engine/Xenko.Physics/Shapes/StaticPlaneColliderShape.cs
@@ -40,7 +40,7 @@ namespace Xenko.Physics
             Matrix rotationMatrix;
             var oY = Vector3.Normalize(Normal);
             var oZ = Vector3.Cross(Vector3.UnitX, oY);
-            if (oZ.Length() > MathUtil.ZeroTolerance)
+            if (oZ.LengthSquared() > MathUtil.ZeroTolerance)
             {
                 oZ.Normalize();
                 var oX = Vector3.Cross(oY, oZ);

--- a/sources/engine/Xenko.Rendering/Rendering/Lights/LightSkyboxRenderer.cs
+++ b/sources/engine/Xenko.Rendering/Rendering/Lights/LightSkyboxRenderer.cs
@@ -146,14 +146,13 @@ namespace Xenko.Rendering.Lights
                 {
                     specularCubemapLevels = specularCubemap.MipLevels;
                 }
-                var sphericalColors = diffuseParameters.GetValues(SphericalHarmonicsEnvironmentColorKeys.SphericalColors);
 
                 // global parameters
                 parameters.Set(intensityKey, intensity);
                 parameters.Set(skyMatrixKey, skyMatrix);
 
                 // This need to be working with new system
-                parameters.Set(sphericalColorsKey, sphericalColors);
+                diffuseParameters.CopyTo(SphericalHarmonicsEnvironmentColorKeys.SphericalColors, parameters, sphericalColorsKey);
                 parameters.Set(specularCubeMapkey, specularCubemap);
                 parameters.Set(specularMipCountKey, specularCubemapLevels);
             }

--- a/sources/engine/Xenko.Rendering/Rendering/RenderContext.cs
+++ b/sources/engine/Xenko.Rendering/Rendering/RenderContext.cs
@@ -171,16 +171,20 @@ namespace Xenko.Rendering
 
         public void Reset()
         {
-            foreach (var context in threadContext.Values)
+            var contextList = threadContext.Values;     // returns IList so don't use foreach otherwise an object will be allocated
+            for (int i = 0; i < contextList.Count; i++)
             {
+                var context = contextList[i];
                 context.ResourceGroupAllocator.Reset(context.CommandList);
             }
         }
 
         public void Flush()
         {
-            foreach (var context in threadContext.Values)
+            var contextList = threadContext.Values;     // returns IList so don't use foreach otherwise an object will be allocated
+            for (int i = 0; i < contextList.Count; i++)
             {
+                var context = contextList[i];
                 context.ResourceGroupAllocator.Flush();
                 context.QueryManager.Flush();
             }

--- a/sources/engine/Xenko.Rendering/Streaming/StreamingManager.cs
+++ b/sources/engine/Xenko.Rendering/Streaming/StreamingManager.cs
@@ -438,9 +438,9 @@ namespace Xenko.Streaming
                 return;
 
             // Update resources
-            lock (resources)
+            if (Enabled)
             {
-                if (Enabled)
+                lock (resources)
                 {
                     // Perform synchronization
                     FlushSync();
@@ -558,7 +558,7 @@ namespace Xenko.Streaming
 
         private void FlushSync()
         {
-            for (int i = 0; i < activeStreaming.Count; i++)
+            for (int i = activeStreaming.Count - 1; i >= 0; i--)
             {
                 var resource = activeStreaming[i];
                 if (resource.IsTaskActive)
@@ -566,7 +566,6 @@ namespace Xenko.Streaming
 
                 resource.FlushSync();
                 activeStreaming.RemoveAt(i);
-                i--;
             }
         }
 

--- a/sources/engine/Xenko/Rendering/ParameterCollection.cs
+++ b/sources/engine/Xenko/Rendering/ParameterCollection.cs
@@ -210,7 +210,7 @@ namespace Xenko.Rendering
             if (accessor.BindingSlot == -1)
                 return parameter.DefaultValueMetadataT.DefaultValue;
 
-            return Get(GetAccessor(parameter, createIfNew));
+            return Get(accessor);
         }
 
         /// <summary>
@@ -236,7 +236,7 @@ namespace Xenko.Rendering
             if (accessor.BindingSlot == -1)
                 return parameter.DefaultValueMetadataT.DefaultValue;
 
-            return Get(GetAccessor(parameter));
+            return Get(accessor);
         }
 
         /// <summary>

--- a/sources/engine/Xenko/Rendering/ParameterCollection.cs
+++ b/sources/engine/Xenko/Rendering/ParameterCollection.cs
@@ -318,6 +318,35 @@ namespace Xenko.Rendering
         }
 
         /// <summary>
+        /// Copies all blittable values of a given key to the specified <see cref="ParameterCollection"/>.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="key">The key for the values to copy.</param>
+        /// <param name="destination">The collection to copy the values to.</param>
+        /// <param name="destinationKey">The key for the values of the destination collection.</param>
+        public unsafe void CopyTo<T>(ValueParameterKey<T> key, ParameterCollection destination, ValueParameterKey<T> destinationKey) where T : struct
+        {
+            var sourceParameter = GetAccessor(key);
+            var destParameter = destination.GetAccessor(destinationKey, sourceParameter.Count);
+            if (sourceParameter.Count > destParameter.Count)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            // Align to float4
+            var stride = (Utilities.SizeOf<T>() + 15) / 16 * 16;
+            var sizeInBytes = sourceParameter.Count * stride;
+
+            fixed (byte* sourceDataValues = DataValues)
+            fixed (byte* destDataValues = destination.DataValues)
+            {
+                var sourcePtr = (IntPtr)sourceDataValues + sourceParameter.Offset;
+                var destPtr = (IntPtr)destDataValues + destParameter.Offset;
+                Utilities.CopyMemory(destPtr, sourcePtr, sizeInBytes);
+            }
+        }
+
+        /// <summary>
         /// Sets a blittable value.
         /// </summary>
         /// <typeparam name="T"></typeparam>


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
More minor perf tricks.

## Description

<!--- Describe your changes in detail -->
1. Inherit IEquatable where a struct is used as a dictionary key to avoid boxing.
2. StreamingManager & LightClusteredPointSpotGroupRenderer to remove items in reverse to avoid O(n^2). The StreamingManager performs a `FlushSync` on removal, so this might be a breaking change (ie. a subtle behavior change by flushing in reverse). The alternative is to use `RemoveAll` + predicate to ensure the behavior is consistent at a slight perf cost (see benchmark further down the page).
3. LightClusteredPointSpotGroupRenderer to use `ref` to avoid struct copies, initialize lights directly by array to avoid constant size checks in FastStructList Add method.
4. Faster BoundingFrustum constructor by avoid needless intermediate struct constructors/copying. A new `Plane.Normalize` static method is added, not sure if this should just be internal or public is fine (currently public).
5. Removed chained assignments in Color constructors.
6. Removed second `GetAccessor` calls in `ParameterCollection.Get`. Might need someone to double check this. It looks reasonable to me to not need to call again, nothing exploded when ran on some sample templates.
7. Grid is rewritten so the data of each "dimension" is grouped together in a struct so it's (slightly) easier to understand the context per dimension. The actual 'meat' of the code is largely unchanged, other than some variable hoisting/caching which provide a minor perf improvement.
8. UI code and StaticPlaneColliderShape to test the vector's length squared against `MathUtil.ZeroTolerance` to avoid square root cost. For very small numbers square rooting will return a larger value, so this might be a breaking change for an extreme edge case. Not sure if this should actually be tested against something like `MathUtil.ZeroToleranceSquared`?
9. `ThreadLocal<RenderDrawContext>.Values` returns an IList so avoid foreach to reduce enumerable object allocation.
10. Add new `ParameterCollection.GetValues` method to have an array ref parameter to reduce array object allocations. ~This is a breaking change if any external users are using this. Maybe retain the old one and just mark obsolete?~ Original version is marked obsolete.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Some benchmark results:

2. StreamingManager: assume 8 tasks finished simultaneously.
```
|                        Method |       Runtime |     Mean |    Error |   StdDev |
|------------------------------ |-------------- |---------:|---------:|---------:|
|     FlushSync_RemoveAtForward |    .NET 4.6.1 | 69.24 ms | 0.627 ms | 0.587 ms |
|     FlushSync_RemoveAtReverse |    .NET 4.6.1 | 26.49 ms | 0.522 ms | 0.580 ms |
| FlushSync_RemoveWithPredicate |    .NET 4.6.1 | 39.01 ms | 0.603 ms | 0.564 ms |
|     FlushSync_RemoveAtForward | .NET Core 2.0 | 81.46 ms | 0.368 ms | 0.326 ms |
|     FlushSync_RemoveAtReverse | .NET Core 2.0 | 27.15 ms | 0.395 ms | 0.350 ms |
| FlushSync_RemoveWithPredicate | .NET Core 2.0 | 33.33 ms | 0.286 ms | 0.267 ms |
```
Have tested 3 & 15 tasks finished simultaneously. RemoveAtReverse still performed the fastest, but has a subtle behavior change.

3. LightClusteredPointSpotGroupRenderer: test RemoveAt from forward to reverse or use predicate, assume four lights which are always accepted.
Test struct variable usage by ref
```
|                                                     Method |       Runtime |       Mean |     Error |    StdDev |
|----------------------------------------------------------- |-------------- |-----------:|----------:|----------:|
|         ProcessLights_PopulateLightIndicesByAddAndRemoveAt |    .NET 4.6.1 | 141.749 ms | 1.1856 ms | 0.9900 ms |
| ProcessLights_PopulateLightIndicesByAddAndRemoveAtReversed |    .NET 4.6.1 |  89.820 ms | 1.4579 ms | 1.3637 ms |
| ProcessLights_PopulateLightIndicesByMarkAndRemovePredicate |    .NET 4.6.1 | 109.084 ms | 0.9180 ms | 0.7666 ms |
|                   ComputeViewsParameter_CopyRenderViewInfo |    .NET 4.6.1 |  22.594 ms | 0.4301 ms | 0.4224 ms |
|     ComputeViewsParameter_RenderViewInfoIndexMultipleTimes |    .NET 4.6.1 |   8.874 ms | 0.1737 ms | 0.2546 ms |
|                    ComputeViewsParameter_RenderViewInfoRef |    .NET 4.6.1 |   8.927 ms | 0.1739 ms | 0.2494 ms |
|         ProcessLights_PopulateLightIndicesByAddAndRemoveAt | .NET Core 2.0 | 116.947 ms | 2.2548 ms | 2.1091 ms |
| ProcessLights_PopulateLightIndicesByAddAndRemoveAtReversed | .NET Core 2.0 |  59.784 ms | 0.8129 ms | 0.7604 ms |
| ProcessLights_PopulateLightIndicesByMarkAndRemovePredicate | .NET Core 2.0 |  60.925 ms | 1.1712 ms | 1.0955 ms |
|                   ComputeViewsParameter_CopyRenderViewInfo | .NET Core 2.0 |  19.884 ms | 0.1988 ms | 0.1860 ms |
|     ComputeViewsParameter_RenderViewInfoIndexMultipleTimes | .NET Core 2.0 |   6.556 ms | 0.1309 ms | 0.2114 ms |
|                    ComputeViewsParameter_RenderViewInfoRef | .NET Core 2.0 |   6.346 ms | 0.1256 ms | 0.1841 ms |
```
RemoveAt by reverse is fastest.
The other test avoided a needless struct copy which was faster, as expected.

4. BoundingFrustum: constructor to create normalized plane with 'out' parameter & individual components
```
|                                         Method |       Runtime |       Mean |    Error |   StdDev |
|----------------------------------------------- |-------------- |-----------:|---------:|---------:|
|            BoundingFrustum_ConstructorOriginal |    .NET 4.6.1 | 1,722.3 ms | 22.17 ms | 19.66 ms |
| BoundingFrustum_ConstructorAssignThenNormalize |    .NET 4.6.1 | 1,351.1 ms |  7.07 ms |  6.61 ms |
|  BoundingFrustum_ConstructorNormalizeImmediate |    .NET 4.6.1 |   617.7 ms |  1.47 ms |  1.23 ms |
|            BoundingFrustum_ConstructorOriginal | .NET Core 2.0 | 1,667.0 ms | 31.64 ms | 31.08 ms |
| BoundingFrustum_ConstructorAssignThenNormalize | .NET Core 2.0 | 1,364.6 ms | 19.09 ms | 17.86 ms |
|  BoundingFrustum_ConstructorNormalizeImmediate | .NET Core 2.0 |   695.5 ms |  0.74 ms |  0.58 ms |
```
Avoids needless struct copies, so this was expected.

5. Color: constructor don't chain assignments
```
|                        Method |       Runtime |     Mean |    Error |   StdDev |
|------------------------------ |-------------- |---------:|---------:|---------:|
|        Color_EmptyConstructor |    .NET 4.6.1 | 11.44 ms | 0.220 ms | 0.206 ms |
|       Color_EmptyConstructor2 |    .NET 4.6.1 | 11.24 ms | 0.215 ms | 0.239 ms |
|                 Color_Default |    .NET 4.6.1 | 11.20 ms | 0.163 ms | 0.153 ms |
|                Color_Default2 |    .NET 4.6.1 | 11.07 ms | 0.091 ms | 0.081 ms |
|   Color_ConstructorArgOneByte |    .NET 4.6.1 | 37.16 ms | 0.474 ms | 0.444 ms |
|  Color_ConstructorArgOneByte2 |    .NET 4.6.1 | 17.74 ms | 0.282 ms | 0.264 ms |
|  Color_ConstructorArgOneFloat |    .NET 4.6.1 | 49.97 ms | 0.924 ms | 0.864 ms |
| Color_ConstructorArgOneFloat2 |    .NET 4.6.1 | 34.97 ms | 0.482 ms | 0.451 ms |
|     Color_ConstructorArgThree |    .NET 4.6.1 | 17.66 ms | 0.324 ms | 0.303 ms |
|    Color_ConstructorArgThree2 |    .NET 4.6.1 | 17.22 ms | 0.047 ms | 0.042 ms |
|        Color_EmptyConstructor | .NET Core 2.0 | 11.08 ms | 0.111 ms | 0.104 ms |
|       Color_EmptyConstructor2 | .NET Core 2.0 | 11.30 ms | 0.219 ms | 0.285 ms |
|                 Color_Default | .NET Core 2.0 | 11.33 ms | 0.223 ms | 0.312 ms |
|                Color_Default2 | .NET Core 2.0 | 11.61 ms | 0.182 ms | 0.170 ms |
|   Color_ConstructorArgOneByte | .NET Core 2.0 | 37.32 ms | 0.354 ms | 0.332 ms |
|  Color_ConstructorArgOneByte2 | .NET Core 2.0 | 17.54 ms | 0.110 ms | 0.092 ms |
|  Color_ConstructorArgOneFloat | .NET Core 2.0 | 49.23 ms | 0.411 ms | 0.384 ms |
| Color_ConstructorArgOneFloat2 | .NET Core 2.0 | 38.43 ms | 0.391 ms | 0.366 ms |
|     Color_ConstructorArgThree | .NET Core 2.0 | 17.51 ms | 0.055 ms | 0.046 ms |
|    Color_ConstructorArgThree2 | .NET Core 2.0 | 17.84 ms | 0.234 ms | 0.219 ms |
```
Same performance difference noticed in a previous perf fix.

7. Grid: code restructure by grouping dimension data together
```
|                      Method |       Runtime |     Mean |   Error |  StdDev |
|---------------------------- |-------------- |---------:|--------:|--------:|
|        Measure_OriginalCode |    .NET 4.6.1 | 824.6 ms | 5.17 ms | 4.83 ms |
| Measure_CachePropertiesOnly |    .NET 4.6.1 | 751.5 ms | 1.61 ms | 1.50 ms |
|   Measure_NewStructGrouping |    .NET 4.6.1 | 752.2 ms | 3.59 ms | 3.18 ms |
|        Measure_OriginalCode | .NET Core 2.0 | 804.1 ms | 1.69 ms | 1.42 ms |
| Measure_CachePropertiesOnly | .NET Core 2.0 | 746.4 ms | 6.49 ms | 6.07 ms |
|   Measure_NewStructGrouping | .NET Core 2.0 | 738.9 ms | 1.94 ms | 1.72 ms |
```
The caching has perf improvement, the grouping is only for code clarity.

8. Vector2/Vecotr3: LengthSquared vs Length performance
```
|                                      Method |       Runtime |      Mean |     Error |    StdDev |
|-------------------------------------------- |-------------- |----------:|----------:|----------:|
|               Vector2_LengthVsZeroTolerance |    .NET 4.6.1 | 11.557 ms | 0.0594 ms | 0.0556 ms |
| Vector2_LengthSquaredVsZeroToleranceSquared |    .NET 4.6.1 |  5.338 ms | 0.0531 ms | 0.0497 ms |
|        Vector2_LengthSquaredVsZeroTolerance |    .NET 4.6.1 |  5.136 ms | 0.0944 ms | 0.0883 ms |
|               Vector3_LengthVsZeroTolerance |    .NET 4.6.1 | 11.986 ms | 0.2003 ms | 0.1874 ms |
| Vector3_LengthSquaredVsZeroToleranceSquared |    .NET 4.6.1 |  5.889 ms | 0.1031 ms | 0.0965 ms |
|        Vector3_LengthSquaredVsZeroTolerance |    .NET 4.6.1 |  5.902 ms | 0.0890 ms | 0.0833 ms |
|               Vector2_LengthVsZeroTolerance | .NET Core 2.0 | 11.636 ms | 0.1311 ms | 0.1226 ms |
| Vector2_LengthSquaredVsZeroToleranceSquared | .NET Core 2.0 |  4.191 ms | 0.0093 ms | 0.0087 ms |
|        Vector2_LengthSquaredVsZeroTolerance | .NET Core 2.0 |  4.288 ms | 0.0581 ms | 0.0515 ms |
|               Vector3_LengthVsZeroTolerance | .NET Core 2.0 | 11.704 ms | 0.1539 ms | 0.1440 ms |
| Vector3_LengthSquaredVsZeroToleranceSquared | .NET Core 2.0 |  5.567 ms | 0.0506 ms | 0.0474 ms |
|        Vector3_LengthSquaredVsZeroTolerance | .NET Core 2.0 |  5.545 ms | 0.0096 ms | 0.0085 ms |
```
Obviously ZeroTolerance and ZeroToleranceSquared has no impact since they're both const, the difference is in Length vs LengthSquared.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.