### PR TITLE
[GameStudio] Changed default value for remote effect compilation sett…

### DIFF
--- a/sources/editor/Xenko.Core.Assets.Editor/Settings/EditorSettings.cs
+++ b/sources/editor/Xenko.Core.Assets.Editor/Settings/EditorSettings.cs
@@ -83,7 +83,7 @@ namespace Xenko.Core.Assets.Editor.Settings
             };
             FallbackBuildCacheDirectory = new UDirectory(Path.Combine(EditorPath.DefaultTempPath, "BuildCache"));
 
-            UseEffectCompilerServer = new SettingsKey<bool>("Tools/UseEffectCompilerServer", SettingsContainer, true)
+            UseEffectCompilerServer = new SettingsKey<bool>("Tools/UseEffectCompilerServer", SettingsContainer, false)
             {
                 DisplayName = $"{Tools}/{Tr._p("Settings", "Use effect compiler server for mobile platforms")}",
             };

--- a/sources/engine/Xenko.Assets/GameUserSettings.cs
+++ b/sources/engine/Xenko.Assets/GameUserSettings.cs
@@ -11,11 +11,11 @@ namespace Xenko.Assets
     {
         public static class Effect
         {
-            public static SettingsKey<EffectCompilationMode> EffectCompilation = new SettingsKey<EffectCompilationMode>("Package/Game/Effect/EffectCompilation", PackageUserSettings.SettingsContainer, EffectCompilationMode.LocalOrRemote)
+            public static SettingsKey<EffectCompilationMode> EffectCompilation = new SettingsKey<EffectCompilationMode>("Package/Game/Effect/EffectCompilation", PackageUserSettings.SettingsContainer, EffectCompilationMode.Local)
             {
                 DisplayName = "Effect Compiler"
             };
-            public static SettingsKey<bool> RecordUsedEffects = new SettingsKey<bool>("Package/Game/Effect/RecordUsedEffects", PackageUserSettings.SettingsContainer, true)
+            public static SettingsKey<bool> RecordUsedEffects = new SettingsKey<bool>("Package/Game/Effect/RecordUsedEffects", PackageUserSettings.SettingsContainer, false)
             {
                 DisplayName = "Record used effects"
             };


### PR DESCRIPTION
# PR Details

Change the default value of remote effect compilation to disable.

## Description

The default value for remote effect compilation is enable at the moment in GameStudio, this cause an exception when is not possible to connect to the server. 

"[RouterClient]: Error: Could not connect to connection router using mode Connect. System.AggregateException: One or more errors occurred. ---> System.Net.Sockets.SocketException: No connection could be made because the target machine actively refused it 127.0.0.1:31254"

![Record](https://user-images.githubusercontent.com/10274446/77855446-67708480-71e8-11ea-9464-5291bedaed65.PNG)
![image](https://user-images.githubusercontent.com/10274446/77855473-925ad880-71e8-11ea-8c3f-715f2e223dca.png)


## Related Issue

#254 
https://forums.xenko.com/t/routerclient-cs-is-throwing-an-exception/724


## Motivation and Context

- All the end users of Game Studio are impacted with the remote compilation enabled by default since any Game project created from the templates will crash when built.
- It's not everyone that requires to use this feature
- Game.cs is using already disable as default https://github.com/stride3d/xenko/blob/e6f55ee3ed4c97173a5353faa03fe7686632b7ed/sources/engine/Xenko.Engine/Engine/Game.cs#L376

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.