### PR TITLE
Fix YAML serialization when control subclasses override the default values

### DIFF
--- a/sources/assets/Xenko.Core.Assets/Tracking/SourceHashesHelper.cs
+++ b/sources/assets/Xenko.Core.Assets/Tracking/SourceHashesHelper.cs
@@ -112,7 +112,14 @@ namespace Xenko.Core.Assets.Tracking
         {
             public const int DefaultOrder = int.MaxValue;
 
-            public static readonly SourceHashesDynamicMember Default = new SourceHashesDynamicMember { ShouldSerialize = x => { var asset = x as Asset; return asset != null && TryGet(asset, AbsoluteSourceHashesKey)?.Count > 0; } };
+            public static readonly SourceHashesDynamicMember Default = new SourceHashesDynamicMember
+            {
+                ShouldSerialize = (x, parentTypeMemberDesc) =>
+                {
+                    var asset = x as Asset;
+                    return asset != null && TryGet(asset, AbsoluteSourceHashesKey)?.Count > 0;
+                }
+            };
 
             static SourceHashesDynamicMember()
             {

--- a/sources/assets/Xenko.Core.Assets/Yaml/AssetObjectSerializerBackend.cs
+++ b/sources/assets/Xenko.Core.Assets/Yaml/AssetObjectSerializerBackend.cs
@@ -30,7 +30,7 @@ namespace Xenko.Core.Yaml
 
         public override object ReadMemberValue(ref ObjectContext objectContext, IMemberDescriptor memberDescriptor, object memberValue, Type memberType)
         {
-            var memberObjectContext = new ObjectContext(objectContext.SerializerContext, memberValue, objectContext.SerializerContext.FindTypeDescriptor(memberType));
+            var memberObjectContext = new ObjectContext(objectContext.SerializerContext, memberValue, objectContext.SerializerContext.FindTypeDescriptor(memberType), objectContext.Descriptor, memberDescriptor);
 
             var member = memberDescriptor as MemberDescriptorBase;
             if (member != null && objectContext.Settings.Attributes.GetAttribute<NonIdentifiableCollectionItemsAttribute>(member.MemberInfo) != null)
@@ -48,7 +48,7 @@ namespace Xenko.Core.Yaml
 
         public override void WriteMemberValue(ref ObjectContext objectContext, IMemberDescriptor memberDescriptor, object memberValue, Type memberType)
         {
-            var memberObjectContext = new ObjectContext(objectContext.SerializerContext, memberValue, objectContext.SerializerContext.FindTypeDescriptor(memberType))
+            var memberObjectContext = new ObjectContext(objectContext.SerializerContext, memberValue, objectContext.SerializerContext.FindTypeDescriptor(memberType), objectContext.Descriptor, memberDescriptor)
             {
                 ScalarStyle = memberDescriptor.ScalarStyle,
             };
@@ -153,9 +153,9 @@ namespace Xenko.Core.Yaml
         {
             var path = GetCurrentPath(ref objectContext, true);
             path.PushIndex(index);
-            var itemObjectcontext = new ObjectContext(objectContext.SerializerContext, item, objectContext.SerializerContext.FindTypeDescriptor(itemType));
-            SetCurrentPath(ref itemObjectcontext, path);
-            WriteYaml(ref itemObjectcontext);
+            var itemObjectContext = new ObjectContext(objectContext.SerializerContext, item, objectContext.SerializerContext.FindTypeDescriptor(itemType));
+            SetCurrentPath(ref itemObjectContext, path);
+            WriteYaml(ref itemObjectContext);
         }
 
         public override object ReadDictionaryKey(ref ObjectContext objectContext, Type keyType)
@@ -285,9 +285,9 @@ namespace Xenko.Core.Yaml
             {
                 path.PushIndex(key);
             }
-            var itemObjectcontext = new ObjectContext(objectContext.SerializerContext, value, objectContext.SerializerContext.FindTypeDescriptor(valueType));
-            SetCurrentPath(ref itemObjectcontext, path);
-            WriteYaml(ref itemObjectcontext);
+            var itemObjectContext = new ObjectContext(objectContext.SerializerContext, value, objectContext.SerializerContext.FindTypeDescriptor(valueType));
+            SetCurrentPath(ref itemObjectContext, path);
+            WriteYaml(ref itemObjectContext);
         }
 
         public override bool ShouldSerialize(IMemberDescriptor member, ref ObjectContext objectContext)

--- a/sources/core/Xenko.Core.Reflection/MemberDescriptors/IMemberDescriptor.cs
+++ b/sources/core/Xenko.Core.Reflection/MemberDescriptors/IMemberDescriptor.cs
@@ -6,6 +6,8 @@ using System.Reflection;
 
 namespace Xenko.Core.Reflection
 {
+    public delegate bool ShouldSerializePredicate(object value, IMemberDescriptor parentTypeMemberDescriptor);
+
     /// <summary>
     /// Describe a member of an object.
     /// </summary>
@@ -47,8 +49,8 @@ namespace Xenko.Core.Reflection
         ITypeDescriptor TypeDescriptor { get; }
 
         /// <summary>
-        /// Gets the order of this member. 
-        /// Default is -1, meaning that it is using the alphabetical order 
+        /// Gets the order of this member.
+        /// Default is -1, meaning that it is using the alphabetical order
         /// based on the name of this property.
         /// </summary>
         /// <value>The order.</value>
@@ -75,7 +77,10 @@ namespace Xenko.Core.Reflection
         /// <summary>
         /// Gets a value indicating whether this member should be serialized.
         /// </summary>
-        Func<object, bool> ShouldSerialize { get; }
+        ShouldSerializePredicate ShouldSerialize { get; }
+
+        bool HasDefaultValue { get; }
+        object DefaultValue { get; }
 
         /// <summary>
         /// Gets the alternative names that will map back to this member (may be null).

--- a/sources/core/Xenko.Core.Reflection/MemberDescriptors/MemberDescriptorBase.cs
+++ b/sources/core/Xenko.Core.Reflection/MemberDescriptors/MemberDescriptorBase.cs
@@ -77,7 +77,11 @@ namespace Xenko.Core.Reflection
         /// <value>The member information.</value>
         public MemberInfo MemberInfo { get; }
 
-        public Func<object, bool> ShouldSerialize { get; set; }
+        public ShouldSerializePredicate ShouldSerialize { get; set; }
+
+        public System.ComponentModel.DefaultValueAttribute DefaultValueAttribute { get; set; }
+        public bool HasDefaultValue => DefaultValueAttribute != null;
+        public object DefaultValue => DefaultValueAttribute.Value;
 
         public List<string> AlternativeNames { get; set; }
 

--- a/sources/core/Xenko.Core.Reflection/TypeDescriptors/CollectionDescriptor.cs
+++ b/sources/core/Xenko.Core.Reflection/TypeDescriptors/CollectionDescriptor.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
 using Xenko.Core.Yaml.Serialization;
 
 namespace Xenko.Core.Reflection
@@ -59,7 +60,7 @@ namespace Xenko.Core.Reflection
             }
             var itype = type.GetInterface(typeof(ICollection<>));
 
-            // implements ICollection<T> 
+            // implements ICollection<T>
             if (!typeSupported && itype != null)
             {
                 var remove = itype.GetMethod(nameof(ICollection<object>.Remove), new[] { ElementType });
@@ -290,7 +291,7 @@ namespace Xenko.Core.Reflection
             return TypeHelper.IsCollection(type);
         }
 
-        protected override bool PrepareMember(MemberDescriptorBase member)
+        protected override bool PrepareMember(MemberDescriptorBase member, MemberInfo metadataClassMemberInfo)
         {
             // Filter members
             if (member is PropertyDescriptor && ListOfMembersToRemove.Contains(member.OriginalName))
@@ -299,7 +300,7 @@ namespace Xenko.Core.Reflection
                 return false;
             }
 
-            return !IsCompilerGenerated && base.PrepareMember(member);
+            return !IsCompilerGenerated && base.PrepareMember(member, metadataClassMemberInfo);
         }
     }
 }

--- a/sources/core/Xenko.Core.Reflection/TypeDescriptors/DictionaryDescriptor.cs
+++ b/sources/core/Xenko.Core.Reflection/TypeDescriptors/DictionaryDescriptor.cs
@@ -280,7 +280,7 @@ namespace Xenko.Core.Reflection
             return dictionary.Select(keyValue => new KeyValuePair<object, object>(keyValue.Key, keyValue.Value));
         }
 
-        protected override bool PrepareMember(MemberDescriptorBase member)
+        protected override bool PrepareMember(MemberDescriptorBase member, MemberInfo metadataClassMemberInfo)
         {
             // Filter members
             if (member is PropertyDescriptor && ListOfMembersToRemove.Contains(member.OriginalName))
@@ -289,7 +289,7 @@ namespace Xenko.Core.Reflection
                 return false;
             }
 
-            return base.PrepareMember(member);
+            return base.PrepareMember(member, metadataClassMemberInfo);
         }
     }
 }

--- a/sources/core/Xenko.Core.Reflection/TypeDescriptors/ObjectDescriptor.cs
+++ b/sources/core/Xenko.Core.Reflection/TypeDescriptors/ObjectDescriptor.cs
@@ -17,7 +17,7 @@ namespace Xenko.Core.Reflection
     public class ObjectDescriptor : ITypeDescriptor
     {
         protected static readonly string SystemCollectionsNamespace = typeof(int).Namespace;
-        public static readonly Func<object, bool> ShouldSerializeDefault = o => true;
+        public static readonly ShouldSerializePredicate ShouldSerializeDefault = (obj, parentTypeMemberDesc) => true;
         private static readonly List<IMemberDescriptor> EmptyMembers = new List<IMemberDescriptor>();
 
         private readonly ITypeDescriptorFactory factory;
@@ -136,7 +136,7 @@ namespace Xenko.Core.Reflection
             var memberList = PrepareMembers();
 
             // Sort members by name
-            // This is to make sure that properties/fields for an object 
+            // This is to make sure that properties/fields for an object
             // are always displayed in the same order
             if (keyComparer != null)
             {
@@ -196,6 +196,22 @@ namespace Xenko.Core.Reflection
             }
 
             var bindingFlags = BindingFlags.Instance | BindingFlags.Public;
+
+            var metadataTypeAttributes = Type.GetCustomAttributes<DataContractMetadataTypeAttribute>(inherit: true);
+            var metadataClassMemberInfos = metadataTypeAttributes.Any() ? new List<(MemberInfo MemberInfo, Type MemberType)>() : null;
+            foreach (var metadataTypeAttr in metadataTypeAttributes)
+            {
+                var metadataType = metadataTypeAttr.MetadataClassType;
+                metadataClassMemberInfos.AddRange(from propertyInfo in metadataType.GetProperties(bindingFlags)
+                                                  where propertyInfo.CanRead && propertyInfo.GetIndexParameters().Length == 0 && IsMemberToVisit(propertyInfo)
+                                                  select (propertyInfo as MemberInfo, propertyInfo.PropertyType));
+
+                // Add all public fields
+                metadataClassMemberInfos.AddRange(from fieldInfo in metadataType.GetFields(bindingFlags)
+                                                  where fieldInfo.IsPublic && IsMemberToVisit(fieldInfo)
+                                                  select (fieldInfo as MemberInfo, fieldInfo.FieldType));
+            }
+
             // TODO: we might want an option to disable non-public.
             if (Category == DescriptorCategory.Object)
                 bindingFlags |= BindingFlags.NonPublic;
@@ -204,15 +220,15 @@ namespace Xenko.Core.Reflection
                               where propertyInfo.CanRead && propertyInfo.GetIndexParameters().Length == 0 && IsMemberToVisit(propertyInfo)
                               select new PropertyDescriptor(factory.Find(propertyInfo.PropertyType), propertyInfo, NamingConvention.Comparer)
                               into member
-                              where PrepareMember(member)
-                              select member).Cast<IMemberDescriptor>().ToList();
+                              where PrepareMember(member, metadataClassMemberInfos?.FirstOrDefault(x => x.MemberInfo.Name == member.OriginalName && x.MemberType == member.Type).MemberInfo)
+                              select member as IMemberDescriptor).ToList();
 
             // Add all public fields
             memberList.AddRange(from fieldInfo in Type.GetFields(bindingFlags)
                                 where fieldInfo.IsPublic && IsMemberToVisit(fieldInfo)
                                 select new FieldDescriptor(factory.Find(fieldInfo.FieldType), fieldInfo, NamingConvention.Comparer)
                                 into member
-                                where PrepareMember(member)
+                                where PrepareMember(member, metadataClassMemberInfos?.FirstOrDefault(x => x.MemberInfo.Name == member.OriginalName && x.MemberType == member.Type).MemberInfo)
                                 select member);
 
             // Allows adding dynamic members per type
@@ -221,7 +237,7 @@ namespace Xenko.Core.Reflection
             return memberList;
         }
 
-        protected virtual bool PrepareMember(MemberDescriptorBase member)
+        protected virtual bool PrepareMember(MemberDescriptorBase member, MemberInfo metadataClassMemberInfo)
         {
             var memberType = member.Type;
 
@@ -229,9 +245,15 @@ namespace Xenko.Core.Reflection
             member.Mode = DefaultMemberMode;
             member.Mask = 1;
 
+            var attributes = AttributeRegistry.GetAttributes(member.MemberInfo);
+            if (metadataClassMemberInfo != null)
+            {
+                var metadataAttributes = AttributeRegistry.GetAttributes(metadataClassMemberInfo);
+                attributes.InsertRange(0, metadataAttributes);
+            }
 
             // Gets the style
-            var styleAttribute = AttributeRegistry.GetAttribute<DataStyleAttribute>(member.MemberInfo);
+            var styleAttribute = attributes.FirstOrDefault(x => x is DataStyleAttribute) as DataStyleAttribute;
             if (styleAttribute != null)
             {
                 member.Style = styleAttribute.Style;
@@ -239,7 +261,7 @@ namespace Xenko.Core.Reflection
             }
 
             // Handle member attribute
-            var memberAttribute = AttributeRegistry.GetAttribute<DataMemberAttribute>(member.MemberInfo);
+            var memberAttribute = attributes.FirstOrDefault(x => x is DataMemberAttribute) as DataMemberAttribute;
             if (memberAttribute != null)
             {
                 ((IMemberDescriptor)member).Mask = memberAttribute.Mask;
@@ -267,14 +289,14 @@ namespace Xenko.Core.Reflection
             }
 
             // Process all attributes just once instead of getting them one by one
-            var attributes = AttributeRegistry.GetAttributes(member.MemberInfo);
             DefaultValueAttribute defaultValueAttribute = null;
             foreach (var attribute in attributes)
             {
                 var valueAttribute = attribute as DefaultValueAttribute;
                 if (valueAttribute != null)
                 {
-                    defaultValueAttribute = valueAttribute;
+                    // If we've already found one, don't overwrite it
+                    defaultValueAttribute = defaultValueAttribute ?? valueAttribute;
                     continue;
                 }
 
@@ -291,7 +313,6 @@ namespace Xenko.Core.Reflection
                     }
                 }
             }
-
 
             // If it's a private member, check it has a YamlMemberAttribute on it
             if (!member.IsPublic)
@@ -321,10 +342,11 @@ namespace Xenko.Core.Reflection
             //	  otherwise => true
             var shouldSerialize = Type.GetMethod("ShouldSerialize" + member.OriginalName, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
             if (shouldSerialize != null && shouldSerialize.ReturnType == typeof(bool) && member.ShouldSerialize == null)
-                member.ShouldSerialize = obj => (bool)shouldSerialize.Invoke(obj, EmptyObjectArray);
+                member.ShouldSerialize = (obj, parentTypeMemberDesc) => (bool)shouldSerialize.Invoke(obj, EmptyObjectArray);
 
             if (defaultValueAttribute != null && member.ShouldSerialize == null && !emitDefaultValues)
             {
+                member.DefaultValueAttribute = defaultValueAttribute;
                 object defaultValue = defaultValueAttribute.Value;
                 Type defaultType = defaultValue?.GetType();
                 if (defaultType != null && defaultType.IsNumeric() && defaultType != memberType)
@@ -337,7 +359,20 @@ namespace Xenko.Core.Reflection
                     {
                     }
                 }
-                member.ShouldSerialize = obj => !Equals(defaultValue, member.Get(obj));
+                member.ShouldSerialize = (obj, parentTypeMemberDesc) =>
+                {
+                    if (parentTypeMemberDesc?.HasDefaultValue ?? false)
+                    {
+                        var parentDefaultValue = parentTypeMemberDesc.DefaultValue;
+                        if (parentDefaultValue != null)
+                        {
+                                // The parent class holding this object type has defined it's own default value for this type
+                                var parentDefaultValueMemberValue = member.Get(parentDefaultValue); // This is the real default value for this object
+                                return !Equals(parentDefaultValueMemberValue, member.Get(obj));
+                        }
+                    }
+                    return !Equals(defaultValue, member.Get(obj));
+                };
             }
 
             if (member.ShouldSerialize == null)

--- a/sources/core/Xenko.Core.Yaml.Tests/DescriptorTests.cs
+++ b/sources/core/Xenko.Core.Yaml.Tests/DescriptorTests.cs
@@ -138,15 +138,15 @@ namespace Xenko.Core.Yaml.Tests
             Assert.Equal("property1", instance.Property);
 
             // Check ShouldSerialize
-            Assert.True(descriptor[nameof(TestObject.Name)].ShouldSerialize(instance));
+            Assert.True(descriptor[nameof(TestObject.Name)].ShouldSerialize(instance, null));
 
-            Assert.False(descriptor[nameof(TestObject.Value)].ShouldSerialize(instance));
+            Assert.False(descriptor[nameof(TestObject.Value)].ShouldSerialize(instance, null));
             instance.Value = 1;
-            Assert.True(descriptor[nameof(TestObject.Value)].ShouldSerialize(instance));
+            Assert.True(descriptor[nameof(TestObject.Value)].ShouldSerialize(instance, null));
 
-            Assert.False(descriptor[nameof(TestObject.DefaultValue)].ShouldSerialize(instance));
+            Assert.False(descriptor[nameof(TestObject.DefaultValue)].ShouldSerialize(instance, null));
             instance.DefaultValue++;
-            Assert.True(descriptor[nameof(TestObject.DefaultValue)].ShouldSerialize(instance));
+            Assert.True(descriptor[nameof(TestObject.DefaultValue)].ShouldSerialize(instance, null));
 
             // Check HasSet
             Assert.True(descriptor[nameof(TestObject.Collection)].HasSet);

--- a/sources/core/Xenko.Core.Yaml.Tests/Serialization/SerializationSubClassTests.cs
+++ b/sources/core/Xenko.Core.Yaml.Tests/Serialization/SerializationSubClassTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Xenko contributors (https://xenko.com)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System.ComponentModel;
+using Xenko.Core.Yaml.Serialization;
+using Xunit;
+
+namespace Xenko.Core.Yaml.Tests.Serialization
+{
+    public class SerializationSubClassTests
+    {
+        public class DefaultSizeValueAttribute : DefaultValueAttribute
+        {
+            public DefaultSizeValueAttribute(int width, int height) : base(null)
+            {
+                Width = width;
+                Height = height;
+            }
+
+            public int Width { get; }
+            public int Height { get; }
+
+            public override object Value => new Size { Width = Width, Height = Height };
+        }
+
+        public struct Size
+        {
+            [DefaultValue(0)]
+            public int Width { get; set; }
+
+            [DefaultValue(0)]
+            public int Height { get; set; }
+        }
+
+        public class TestBaseClass
+        {
+            [DefaultValue(false)]
+            public bool IsSelected { get; set; }
+            [DefaultSizeValue(0, 0)]
+            public Size Size { get; set; }
+        }
+
+        [DataContractMetadataType(typeof(TestSubClass1Metadata))]
+        public class TestSubClass1 : TestBaseClass
+        {
+            public TestSubClass1()
+            {
+                IsSelected = true;
+                Size = new Size { Width = 10, Height = 10 };
+            }
+
+            private class TestSubClass1Metadata
+            {
+                [DefaultValue(true)]
+                public bool IsSelected { get; set; }
+                [DefaultSizeValue(10, 10)]
+                public Size Size { get; set; }
+            }
+        }
+
+        [Fact]
+        public void TestSerializeSubClassWithOverriddenDefaultValues()
+        {
+            var settings = new SerializerSettings();
+            settings.RegisterAssembly(typeof(SerializationSubClassTests).Assembly);
+            var serializer = new Serializer(settings);
+
+            var value = new TestSubClass1();
+            var text = serializer.Serialize(value);
+            var newValue = serializer.Deserialize<TestSubClass1>(text);
+            Assert.Equal(value.IsSelected, newValue.IsSelected);
+            Assert.Equal(value.Size.Width, newValue.Size.Width);
+            Assert.Equal(value.Size.Height, newValue.Size.Height);
+        }
+
+        [Fact]
+        public void TestSerializeSubClassWithValuesSameAsBaseClassValues()
+        {
+            var settings = new SerializerSettings();
+            settings.RegisterAssembly(typeof(SerializationSubClassTests).Assembly);
+            var serializer = new Serializer(settings);
+
+            var value = new TestSubClass1();
+            value.IsSelected = false;
+            value.Size = new Size { Width = 10, Height = 10 };
+            var text = serializer.Serialize(value);
+            var newValue = serializer.Deserialize<TestSubClass1>(text);
+            Assert.Equal(value.IsSelected, newValue.IsSelected);
+            Assert.Equal(value.Size.Width, newValue.Size.Width);
+            Assert.Equal(value.Size.Height, newValue.Size.Height);
+        }
+    }
+}

--- a/sources/core/Xenko.Core.Yaml/Serialization/DynamicMemberDescriptorBase.cs
+++ b/sources/core/Xenko.Core.Yaml/Serialization/DynamicMemberDescriptorBase.cs
@@ -76,7 +76,10 @@ namespace Xenko.Core.Yaml.Serialization
 
         public ScalarStyle ScalarStyle { get; set; }
 
-        public Func<object, bool> ShouldSerialize { get; set; }
+        public ShouldSerializePredicate ShouldSerialize { get; set; }
+
+        public bool HasDefaultValue => false;
+        public object DefaultValue => throw new InvalidOperationException();
 
         public List<string> AlternativeNames { get; set; }
 

--- a/sources/core/Xenko.Core.Yaml/Serialization/ObjectContext.cs
+++ b/sources/core/Xenko.Core.Yaml/Serialization/ObjectContext.cs
@@ -39,11 +39,14 @@ namespace Xenko.Core.Yaml.Serialization
         /// <param name="serializerContext">The serializer context.</param>
         /// <param name="instance">The instance.</param>
         /// <param name="descriptor">The descriptor.</param>
-        public ObjectContext(SerializerContext serializerContext, object instance, ITypeDescriptor descriptor) : this()
+        public ObjectContext(SerializerContext serializerContext, object instance, ITypeDescriptor descriptor,
+            ITypeDescriptor parentTypeDescriptor = null, IMemberDescriptor parentTypeMemberDescriptor = null) : this()
         {
             SerializerContext = serializerContext;
             Instance = instance;
             Descriptor = descriptor;
+            ParentTypeDescriptor = parentTypeDescriptor;
+            ParentTypeMemberDescriptor = parentTypeMemberDescriptor;
             Properties = new PropertyContainer();
         }
 
@@ -85,6 +88,16 @@ namespace Xenko.Core.Yaml.Serialization
         /// The expected type descriptor.
         /// </summary>
         public ITypeDescriptor Descriptor { get; set; }
+
+        /// <summary>
+        /// The type descriptor of the parent of the instance type.
+        /// </summary>
+        public ITypeDescriptor ParentTypeDescriptor { get; set; }
+
+        /// <summary>
+        /// The type descriptor of the parent's member that generates this type of instance.
+        /// </summary>
+        public IMemberDescriptor ParentTypeMemberDescriptor { get; set; }
 
         /// <summary>
         /// The tag used when serializing.

--- a/sources/core/Xenko.Core.Yaml/Serialization/Serializers/DefaultObjectSerializerBackend.cs
+++ b/sources/core/Xenko.Core.Yaml/Serialization/Serializers/DefaultObjectSerializerBackend.cs
@@ -139,7 +139,7 @@ namespace Xenko.Core.Yaml.Serialization.Serializers
         public virtual void WriteMemberValue(ref ObjectContext objectContext, IMemberDescriptor memberDescriptor, object memberValue, Type memberType)
         {
             // Push the style of the current member
-            var memberObjectContext = new ObjectContext(objectContext.SerializerContext, memberValue, objectContext.SerializerContext.FindTypeDescriptor(memberType))
+            var memberObjectContext = new ObjectContext(objectContext.SerializerContext, memberValue, objectContext.SerializerContext.FindTypeDescriptor(memberType), objectContext.ParentTypeDescriptor, memberDescriptor)
             {
                 Style = memberDescriptor.Style,
                 ScalarStyle = memberDescriptor.ScalarStyle,
@@ -169,7 +169,7 @@ namespace Xenko.Core.Yaml.Serialization.Serializers
         }
 
         /// <inheritdoc/>
-        public virtual bool ShouldSerialize(IMemberDescriptor member, ref ObjectContext objectContext) => member.ShouldSerialize(objectContext.Instance);
+        public virtual bool ShouldSerialize(IMemberDescriptor member, ref ObjectContext objectContext) => member.ShouldSerialize(objectContext.Instance, objectContext.ParentTypeMemberDescriptor);
 
         protected object ReadYaml(ref ObjectContext objectContext)
         {

--- a/sources/core/Xenko.Core/DataContractMetadataTypeAttribute.cs
+++ b/sources/core/Xenko.Core/DataContractMetadataTypeAttribute.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Xenko contributors (https://xenko.com)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+using System;
+
+namespace Xenko.Core
+{
+    /// <summary>
+    /// Specifies the metadata class to associate with a serializable class.
+    /// The main usage of this class is to allow a sub-class to override property
+    /// attributes such as <see cref="System.ComponentModel.DefaultValueAttribute"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+    public class DataContractMetadataTypeAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataContractMetadataTypeAttribute"/> class.
+        /// </summary>
+        /// <param name="metadataClassType">The type alias name when serializing to a textual format.</param>
+        /// <exception cref="ArgumentException"><paramref name="metadataClassType"/> is <c>null</c></exception>
+        public DataContractMetadataTypeAttribute(Type metadataClassType)
+        {
+            MetadataClassType = metadataClassType;
+        }
+
+        /// <summary>
+        /// Gets the metadata class that is associated with a serializable class.
+        /// </summary>
+        public Type MetadataClassType { get; }
+    }
+}

--- a/sources/engine/Xenko.UI/Attributes/DefaultThicknessValueAttribute.cs
+++ b/sources/engine/Xenko.UI/Attributes/DefaultThicknessValueAttribute.cs
@@ -1,0 +1,70 @@
+using System.ComponentModel;
+
+namespace Xenko.UI.Attributes
+{
+    public class DefaultThicknessValueAttribute : DefaultValueAttribute
+    {
+        public DefaultThicknessValueAttribute(float left, float top, float right, float bottom)
+           : base(null)
+        {
+            Bottom = bottom;
+            Left = left;
+            Right = right;
+            Top = top;
+            Front = 0;
+            Back = 0;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Thickness structure that has specific lengths applied to each side of the cuboid.
+        /// </summary>
+        /// <param name="bottom">The thickness for the lower side of the cuboid.</param>
+        /// <param name="left">The thickness for the left side of the cuboid.</param>
+        /// <param name="right">The thickness for the right side of the cuboid</param>
+        /// <param name="top">The thickness for the upper side of the cuboid.</param>
+        /// <param name="front">The thickness for the front side of the cuboid.</param>
+        /// <param name="back">The thickness for the Back side of the cuboid.</param>
+        public DefaultThicknessValueAttribute(float left, float top, float back, float right, float bottom, float front)
+             : base(null)
+        {
+            Bottom = bottom;
+            Left = left;
+            Right = right;
+            Top = top;
+            Front = front;
+            Back = back;
+        }
+
+        /// <summary>
+        /// The Back side of the bounding cuboid.
+        /// </summary>
+        public float Back { get; }
+
+        /// <summary>
+        /// The bottom side of the bounding rectangle or cuboid.
+        /// </summary>
+        public float Bottom;
+
+        /// <summary>
+        /// The front side of the bounding cuboid.
+        /// </summary>
+        public float Front { get; }
+
+        /// <summary>
+        /// The left side of the bounding rectangle or cuboid.
+        /// </summary>
+        public float Left { get; }
+
+        /// <summary>
+        /// The right side of the bounding rectangle or cuboid.
+        /// </summary>
+        public float Right { get; }
+
+        /// <summary>
+        /// The upper side of the bounding rectangle or cuboid.
+        /// </summary>
+        public float Top { get; }
+
+        public override object Value => new Thickness(Left, Top, Back, Right, Bottom, Front);
+    }
+}

--- a/sources/engine/Xenko.UI/Controls/Button.cs
+++ b/sources/engine/Xenko.UI/Controls/Button.cs
@@ -8,6 +8,7 @@ using Xenko.Core;
 using Xenko.Core.Mathematics;
 using Xenko.Engine;
 using Xenko.Graphics;
+using Xenko.UI.Attributes;
 
 namespace Xenko.UI.Controls
 {
@@ -15,6 +16,7 @@ namespace Xenko.UI.Controls
     /// Represents a Windows button control, which reacts to the Click event.
     /// </summary>
     [DataContract(nameof(Button))]
+    [DataContractMetadataType(typeof(ButtonMetadata))]
     [DebuggerDisplay("Button - Name={Name}")]
     public class Button : ButtonBase
     {
@@ -28,7 +30,7 @@ namespace Xenko.UI.Controls
         public Button()
         {
             DrawLayerNumber += 1; // (button design image)
-            Padding = new Thickness(10, 5, 10, 7);
+            Padding = new Thickness(10, 5, 10, 7);  // Warning: this must also match in ButtonMetadata
 
             MouseOverStateChanged += (sender, args) => InvalidateButtonImage();
         }
@@ -191,11 +193,17 @@ namespace Xenko.UI.Controls
         {
             InvalidateButtonImage();
         }
-        
+
         private void InvalidateButtonImage()
         {
             if (!sizeToContent)
                 InvalidateMeasure();
+        }
+
+        private class ButtonMetadata
+        {
+            [DefaultThicknessValue(10, 5, 10, 7)]
+            public Thickness Padding { get; }
         }
     }
 }

--- a/sources/engine/Xenko.UI/Controls/ButtonBase.cs
+++ b/sources/engine/Xenko.UI/Controls/ButtonBase.cs
@@ -13,6 +13,7 @@ namespace Xenko.UI.Controls
     /// Represents the base primitive for all the button-like controls
     /// </summary>
     [DataContract(nameof(ButtonBase))]
+    [DataContractMetadataType(typeof(ButtonBaseMetadata))]
     [DebuggerDisplay("ButtonBase - Name={Name}")]
     [Display(category: InputCategory)]
     public abstract class ButtonBase : ContentControl
@@ -27,7 +28,7 @@ namespace Xenko.UI.Controls
         /// </summary>
         protected ButtonBase()
         {
-            CanBeHitByUser = true;
+            CanBeHitByUser = true;  // Warning: this must also match in ButtonBaseMetadata
         }
 
         /// <summary>
@@ -73,7 +74,7 @@ namespace Xenko.UI.Controls
             if (ClickMode == ClickMode.Press)
                 RaiseEvent(new RoutedEventArgs(ClickEvent));
         }
-        
+
         protected override void OnTouchUp(TouchEventArgs args)
         {
             base.OnTouchUp(args);
@@ -100,12 +101,18 @@ namespace Xenko.UI.Controls
         {
 
         }
-        
+
         private static void ClickClassHandler(object sender, RoutedEventArgs args)
         {
             var buttonBase = (ButtonBase)sender;
 
             buttonBase.OnClick(args);
+        }
+
+        private class ButtonBaseMetadata
+        {
+            [DefaultValue(true)]
+            public bool CanBeHitByUser { get; set; }
         }
     }
 }

--- a/sources/engine/Xenko.UI/Controls/ImageButton.cs
+++ b/sources/engine/Xenko.UI/Controls/ImageButton.cs
@@ -2,12 +2,15 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 using System;
 using System.Diagnostics;
+using Xenko.Core;
+using Xenko.UI.Attributes;
 
 namespace Xenko.UI.Controls
 {
     /// <summary>
     /// A <see cref="Button"/> whose <see cref="ContentControl.Content"/> are the <see cref="Button.PressedImage"/> and <see cref="Button.NotPressedImage"/>.
     /// </summary>
+    [DataContractMetadataType(typeof(ImageButtonMetadata))]
     [DebuggerDisplay("ImageButton - Name={Name}")]
     [Obsolete("Use Button with SizeToContent set to false.")]
     public class ImageButton : Button
@@ -16,7 +19,7 @@ namespace Xenko.UI.Controls
 
         public ImageButton()
         {
-            Padding = Thickness.UniformCuboid(0);
+            Padding = Thickness.UniformCuboid(0);  // Warning: this must also match in ImageButtonMetadata
             base.Content = contentImageElement;
 
             MouseOverStateChanged += (sender, args) => UpdateContentImage();
@@ -56,6 +59,12 @@ namespace Xenko.UI.Controls
 
                 UpdateContentImage();
             }
+        }
+
+        private class ImageButtonMetadata
+        {
+            [DefaultThicknessValue(0, 0, 0, 0)]
+            public Thickness Padding { get; }
         }
     }
 }

--- a/sources/engine/Xenko.UI/Controls/ModalElement.cs
+++ b/sources/engine/Xenko.UI/Controls/ModalElement.cs
@@ -14,6 +14,7 @@ namespace Xenko.UI.Controls
     /// Represents a modal element that puts an overlay upon the underneath elements and freeze their input.
     /// </summary>
     [DataContract(nameof(ModalElement))]
+    [DataContractMetadataType(typeof(ModalElementMetadata))]
     [DebuggerDisplay("ModalElement - Name={Name}")]
     [Display(category: null)]
     public class ModalElement : ButtonBase
@@ -42,8 +43,8 @@ namespace Xenko.UI.Controls
         {
             OverlayColorInternal = new Color(0, 0, 0, 0.6f);
             DrawLayerNumber += 1; // (overlay)
-            VerticalAlignment = VerticalAlignment.Center;
-            HorizontalAlignment = HorizontalAlignment.Center;
+            VerticalAlignment = VerticalAlignment.Center;       // Warning: this must also match in ModalElementMetadata
+            HorizontalAlignment = HorizontalAlignment.Center;   // Warning: this must also match in ModalElementMetadata
         }
 
         /// <summary>
@@ -97,8 +98,17 @@ namespace Xenko.UI.Controls
 
             var virtualResolution = LayoutingContext.VirtualResolution;
             var worldmatrix = Matrix.Identity;
-            
+
             return CollisionHelper.RayIntersectsRectangle(ref ray, ref worldmatrix, ref virtualResolution, 2, out intersectionPoint);
+        }
+
+        private class ModalElementMetadata
+        {
+            [DefaultValue(HorizontalAlignment.Center)]
+            public HorizontalAlignment HorizontalAlignment { get; }
+
+            [DefaultValue(VerticalAlignment.Center)]
+            public VerticalAlignment VerticalAlignment { get; }
         }
     }
 }

--- a/sources/engine/Xenko.UI/Controls/ScrollViewer.cs
+++ b/sources/engine/Xenko.UI/Controls/ScrollViewer.cs
@@ -12,11 +12,12 @@ using Xenko.Games;
 namespace Xenko.UI.Controls
 {
     /// <summary>
-    /// Represents a scroll viewer. 
+    /// Represents a scroll viewer.
     /// A scroll viewer element has an infinite virtual size defined by its <see cref="ScrollingMode"/>.
     /// The user can move in that virtual size by touching and panning on the screen.
     /// </summary>
     [DataContract(nameof(ScrollViewer))]
+    [DataContractMetadataType(typeof(ScrollViewerMetadata))]
     [DebuggerDisplay("ScrollViewer - Name={Name}")]
     public class ScrollViewer : ContentControl
     {
@@ -175,14 +176,14 @@ namespace Xenko.UI.Controls
         protected IScrollAnchorInfo ContentAsAnchorInfo { get; private set; }
 
         /// <summary>
-        /// The current scroll position (in virtual pixels) of the <see cref="ScrollViewer"/>. 
+        /// The current scroll position (in virtual pixels) of the <see cref="ScrollViewer"/>.
         /// That is, the position of the left-top-front corner of the <see cref="ScrollViewer"/> in its <see cref="Content"/>.
         /// </summary>
         /// <remarks>
         /// <para>If the <see cref="Content"/> of the scroll viewer implements the <see cref="IScrollInfo"/> interface,
         /// the <see cref="ScrollPosition"/> will be <value>0</value> in all directions where <see cref="IScrollInfo.CanScroll"/> is true.</para>
-        /// <para>Note that <see cref="ScrollPosition"/> is valid only when <see cref="UIElement.IsArrangeValid"/> is <value>true</value>. 
-        /// If <see cref="UIElement.IsArrangeValid"/> is <value>false</value>, <see cref="ScrollPosition"/> contains the position of the scrolling 
+        /// <para>Note that <see cref="ScrollPosition"/> is valid only when <see cref="UIElement.IsArrangeValid"/> is <value>true</value>.
+        /// If <see cref="UIElement.IsArrangeValid"/> is <value>false</value>, <see cref="ScrollPosition"/> contains the position of the scrolling
         /// before the action that actually invalidated the layout.</para>
         /// </remarks>
         public Vector3 ScrollPosition => -ScrollOffsets;
@@ -216,8 +217,8 @@ namespace Xenko.UI.Controls
                 SetVisualParent(bar, this);
             }
 
-            CanBeHitByUser = TouchScrollingEnabled;
-            ClipToBounds = true;
+            CanBeHitByUser = TouchScrollingEnabled;     // Warning: this must also match in ScrollViewerMetadata
+            ClipToBounds = true;                        // Warning: this must also match in ScrollViewerMetadata
         }
 
         /// <summary>
@@ -490,10 +491,10 @@ namespace Xenko.UI.Controls
         }
 
         /// <summary>
-        /// Try to scroll to the provided position (in virtual pixels). 
+        /// Try to scroll to the provided position (in virtual pixels).
         /// If the provided translation is too important, it is clamped.
         /// </summary>
-        /// <remarks>Note that the computational cost of <see cref="ScrollTo"/> can be greatly higher than <see cref="ScrollOf"/> 
+        /// <remarks>Note that the computational cost of <see cref="ScrollTo"/> can be greatly higher than <see cref="ScrollOf"/>
         /// when scrolling is delegated to a <see cref="Content"/> virtualizing its items. When possible, prefer call to <see cref="ScrollOf"/></remarks>
         /// <param name="scrollAbsolutePosition">The scroll offsets to apply</param>
         /// <param name="stopScrolling">Indicate if the scrolling should be stopped after the scroll action.</param>
@@ -539,7 +540,7 @@ namespace Xenko.UI.Controls
         }
 
         /// <summary>
-        /// Try to scroll of the provided scrolling translation value from the current position. 
+        /// Try to scroll of the provided scrolling translation value from the current position.
         /// If the provided translation is too important, it is clamped.
         /// </summary>
         /// <param name="scrollTranslation">The scroll translation to perform (in virtual pixels)</param>
@@ -677,7 +678,7 @@ namespace Xenko.UI.Controls
                 // arrange the child
                 VisualContent.Arrange(childSizeWithoutPadding, IsCollapsed);
 
-                // update the scrolling bars 
+                // update the scrolling bars
                 UpdateScrollingBarsSize();
 
                 // update the scrolling
@@ -870,7 +871,7 @@ namespace Xenko.UI.Controls
         }
 
         /// <summary>
-        /// Called by an <see cref="IScrollInfo"/> interface that is attached to a <see cref="ScrollViewer"/> when the value of any scrolling property size changes. 
+        /// Called by an <see cref="IScrollInfo"/> interface that is attached to a <see cref="ScrollViewer"/> when the value of any scrolling property size changes.
         /// Scrolling properties include offset, extent, or viewport.
         /// </summary>
         public void InvalidateScrollInfo()
@@ -895,6 +896,15 @@ namespace Xenko.UI.Controls
         public void InvalidateAnchorInfo()
         {
             // currently nothing to do here.
+        }
+
+        private class ScrollViewerMetadata
+        {
+            [DefaultValue(true)]
+            public bool CanBeHitByUser { get; }
+
+            [DefaultValue(true)]
+            public bool ClipToBounds { get; }
         }
     }
 }

--- a/sources/engine/Xenko.UI/Controls/Slider.cs
+++ b/sources/engine/Xenko.UI/Controls/Slider.cs
@@ -18,6 +18,7 @@ namespace Xenko.UI.Controls
     /// Represents a slider element.
     /// </summary>
     [DataContract(nameof(Slider))]
+    [DataContractMetadataType(typeof(SliderMetadata))]
     [Display(category: InputCategory)]
     public class Slider : UIElement
     {
@@ -255,8 +256,8 @@ namespace Xenko.UI.Controls
         public bool ShouldSnapToTicks
         {
             get { return shouldSnapToTicks; }
-            set 
-            { 
+            set
+            {
                 shouldSnapToTicks = value;
                 Value = Value; // snap if enabled
             }
@@ -287,7 +288,7 @@ namespace Xenko.UI.Controls
                 InvalidateMeasure();
             }
         }
-        
+
         /// <summary>
         /// Gets a value that indicates whether the is currently touched down.
         /// </summary>
@@ -335,7 +336,7 @@ namespace Xenko.UI.Controls
 
         private float CalculateIncreamentValue()
         {
-            return shouldSnapToTicks ? Math.Max(Step, (Maximum - Minimum)/TickFrequency) : Step;
+            return shouldSnapToTicks ? Math.Max(Step, (Maximum - Minimum) / TickFrequency) : Step;
         }
 
         protected override Vector3 MeasureOverride(Vector3 availableSizeWithoutMargins)
@@ -369,7 +370,7 @@ namespace Xenko.UI.Controls
             nameof(ValueChanged),
             RoutingStrategy.Bubble,
             typeof(Slider));
-        
+
         /// <summary>
         /// The class handler of the event <see cref="ValueChanged"/>.
         /// This method can be overridden in inherited classes to perform actions common to all instances of a class.
@@ -390,7 +391,7 @@ namespace Xenko.UI.Controls
         protected override void OnTouchDown(TouchEventArgs args)
         {
             base.OnTouchDown(args);
-            
+
             SetValueFromTouchPosition(args.WorldPosition);
             IsTouchedDown = true;
         }
@@ -438,7 +439,7 @@ namespace Xenko.UI.Controls
             var axis = (int)Orientation;
             var offsets = TrackStartingOffsets;
             var elementSize = RenderSize[axis];
-            var touchPosition = touchPostionWorld[axis] - WorldMatrixInternal[12 + axis] + elementSize/2;
+            var touchPosition = touchPostionWorld[axis] - WorldMatrixInternal[12 + axis] + elementSize / 2;
             var ratio = (touchPosition - offsets.X) / (elementSize - offsets.X - offsets.Y);
             Value = MathUtil.Lerp(Minimum, Maximum, Orientation == Orientation.Vertical ^ IsDirectionReversed ? 1 - ratio : ratio);
         }
@@ -476,6 +477,18 @@ namespace Xenko.UI.Controls
                 trackBackgroundSprite.SizeChanged += InvalidateMeasure;
                 trackBackgroundSprite.BorderChanged += InvalidateMeasure;
             }
+        }
+
+        private class SliderMetadata
+        {
+            [DefaultValue(true)]
+            public bool CanBeHitByUser { get; }
+
+            [DefaultValue(HorizontalAlignment.Center)]
+            public HorizontalAlignment HorizontalAlignment { get; }
+
+            [DefaultValue(VerticalAlignment.Center)]
+            public VerticalAlignment VerticalAlignment { get; }
         }
     }
 }

--- a/sources/engine/Xenko.UI/Controls/ToggleButton.cs
+++ b/sources/engine/Xenko.UI/Controls/ToggleButton.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 
 using Xenko.Core;
 using Xenko.Engine;
+using Xenko.UI.Attributes;
 using Xenko.UI.Events;
 
 namespace Xenko.UI.Controls
@@ -14,6 +15,7 @@ namespace Xenko.UI.Controls
     /// Represent a UI toggle button. A toggle but can have two or three states depending on the <see cref="IsThreeState"/> property.
     /// </summary>
     [DataContract(nameof(ToggleButton))]
+    [DataContractMetadataType(typeof(ToggleButtonMetadata))]
     [DebuggerDisplay("ToggleButton - Name={Name}")]
     public class ToggleButton : ButtonBase
     {
@@ -35,7 +37,7 @@ namespace Xenko.UI.Controls
         public ToggleButton()
         {
             DrawLayerNumber += 1; // (toggle design image)
-            Padding = new Thickness(10, 5, 10, 7);
+            Padding = new Thickness(10, 5, 10, 7);  // Warning: this must also match in ToggleButtonMetadata
         }
 
         /// <summary>
@@ -128,7 +130,7 @@ namespace Xenko.UI.Controls
         [DefaultValue(ToggleState.UnChecked)]
         public ToggleState State
         {
-            get { return state; } 
+            get { return state; }
             set
             {
                 if (state == value)
@@ -234,6 +236,12 @@ namespace Xenko.UI.Controls
             base.OnClick(args);
 
             GoToNextState();
+        }
+
+        private class ToggleButtonMetadata
+        {
+            [DefaultThicknessValue(10, 5, 10, 7)]
+            public Thickness Padding { get; }
         }
     }
 }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Fix YAML bug where derived controls change the default value, which doesn't get detected by the serializer.

## Description

<!--- Describe your changes in detail -->
Added a new attribute to allow for overriding default values via a `DataContractMetadataTypeAttribute`.
This is similar to .NET's [MetadataTypeAttribute](
https://docs.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations.metadatatypeattribute?view=netframework-4.8), however our rules differ slightly. eg. We allow all sub-classes to declare the metadata attribute.
The metadata property is matched on both field/property name AND the data type. This is because a user might hide a property with a new one in the sub class, but it has a different data type (unlikely scenario...?).

The other fix is to push the 'parent' property that generated the value and check the default value from that (if it exists).

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This is my proposal on how to fix issue #111 & #153
There are two issues at hand:
#111 occurs because the control is defining a default value for an entire struct that differs from the default values in the underlying properties. eg. For a `Button.Padding`, the default is expected to be `(10, 5, 10, 7)`, but `Thickness` states the default for each dimension is `0`. The serializer does not account for the 'higher' class' declaration of the default value, so explicitly setting `(0, 0, 0, 0)` is treated as 'do not serialize'.

#153 occurs because only the property with the `DefaultValueAttribute` is considered for the default value during serialization. It is not possible in C# to get a sub-class 'override' the attribute itself.
Inspired by `MetadataTypeAttribute`, this solution allows for sub-classes to 'override' the attribute by declaring it on a metadata class.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Assets are not saved/reloaded correctly due to inconsistent default values between base class and derived classes.

The alternative solutions to a metadata class are:
1. Hide the base class property `public new Thickness Padding { get; set; }`
2. Change the property to `virtual` and override specifically to allow adding an attribute.

Not sure if there is an alternative solution for #111.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.