### PR TITLE
Minor code fixes, remove unsafe method

### DIFF
--- a/sources/core/Xenko.Core.Mathematics/BoundingSphere.cs
+++ b/sources/core/Xenko.Core.Mathematics/BoundingSphere.cs
@@ -50,7 +50,7 @@ namespace Xenko.Core.Mathematics
         public Vector3 Center;
 
         /// <summary>
-        /// The radious of the sphere.
+        /// The radius of the sphere.
         /// </summary>
         public float Radius;
 

--- a/sources/engine/Xenko.Graphics/CommandList.cs
+++ b/sources/engine/Xenko.Graphics/CommandList.cs
@@ -75,7 +75,7 @@ namespace Xenko.Graphics
 
             // Setup empty scissors
             scissorsDirty = true;
-            for (int i = 0; i < viewports.Length; i++)
+            for (int i = 0; i < scissors.Length; i++)
                 scissors[i] = new Rectangle();
 
             // Setup the default render target


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Minor fixes.

## Description

<!--- Describe your changes in detail -->
Use the correct variable for the for-loop bounds check. The two arrays already had the same sizes so it never caused any issues.

Removed `ParameterCollection.GetValuePointer` since the code leaves the `fixed` scope, the pointer can potentially point to an invalid location if the garbage collector moves the array.
The two methods that used it now implement the pointer code correctly.
Any external users that have been using it, 1. shouldn't, 2. have access to `DataValues` and can create a fixed pointer themselves.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.