### PR TITLE
[Editor] Prevent multi-dimensional array from crashing the editor

### DIFF
--- a/sources/core/Xenko.Core.Reflection/TypeDescriptorFactory.cs
+++ b/sources/core/Xenko.Core.Reflection/TypeDescriptorFactory.cs
@@ -96,8 +96,16 @@ namespace Xenko.Core.Reflection
             }
             else if (type.IsArray)
             {
-                // array[]
-                descriptor = new ArrayDescriptor(this, type, emitDefaultValues, namingConvention);
+                if (type.GetArrayRank() == 1)
+                {
+                    // array[] - only single dimension array is supported
+                    descriptor = new ArrayDescriptor(this, type, emitDefaultValues, namingConvention);
+                }
+                else
+                {
+                    // multi-dimension array to be treated as a 'standard' object
+                    descriptor = new ObjectDescriptor(this, type, emitDefaultValues, namingConvention);
+                }
             }
             else if (NullableDescriptor.IsNullable(type))
             {

--- a/sources/editor/Xenko.Core.Assets.Editor/View/DefaultPropertyTemplateProviders.xaml
+++ b/sources/editor/Xenko.Core.Assets.Editor/View/DefaultPropertyTemplateProviders.xaml
@@ -1343,7 +1343,7 @@
   <xk:DefaultTemplateProvider x:Key="ObjectPropertyTemplateProvider" edvw:PropertyViewHelper.TemplateCategory="PropertyEditor" OverrideRule="None">
     <DataTemplate DataType="qvm:NodeViewModel">
       <TextBlock Margin="2,0" VerticalAlignment="Center" x:Name="DefaultTextBlock"
-                       Text="{xk:PriorityBinding {Binding AttributeDisplayName, Mode=OneWay}, {Binding NodeValue, Mode=OneWay, Converter={xk:ObjectToTypeName}}}"/>
+                       Text="{xk:PriorityBinding {Binding AttributeDisplayName, Mode=OneWay}, {Binding NodeValue, Mode=OneWay, StringFormat={xk:Localize {}{0} (Not supported)}, Converter={xk:ObjectToTypeName}}}"/>
       <DataTemplate.Triggers>
         <DataTrigger Binding="{Binding NodeValue}" Value="{x:Static qvm:NodeViewModel.DifferentValues}">
           <Setter TargetName="DefaultTextBlock" Property="Text" Value="{xk:Localize (Different values)}"/>


### PR DESCRIPTION
## PR Details

<!--- Provide a general summary of your changes in the Title above -->
Fix multi-dimensional array crashing the editor.
Annotate 'Not supported' text to property window for unsupported object types.

## Description

<!--- Describe your changes in detail -->
Treat multi-dimensional array as an object type to prevent the editor from crashing.
Append 'Not supported' text to unsupported object types in the property window.
Note that I don't know how localization really works, so would like someone to help in this area.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #431 & #645

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Don't want the editor to crash.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.